### PR TITLE
Add support for "empty response body" (HTTP status code 204)

### DIFF
--- a/examples/response_demo.py
+++ b/examples/response_demo.py
@@ -34,6 +34,16 @@ def hello(path: HelloPath):
     return response
 
 
+@bp.get("/hello_no_response/<string:name>", responses={"204": None})
+def hello_no_response(path: HelloPath):
+    message = {"message": f"""Hello {path.name}!"""}
+
+    # This message will never be returned because the http code (NO_CONTENT) doesn't return anything
+    response = make_response(message, HTTPStatus.NO_CONTENT)
+    response.mimetype = "application/json"
+    return response
+
+
 app.register_api(bp)
 
 if __name__ == "__main__":

--- a/flask_openapi3/api_blueprint.py
+++ b/flask_openapi3/api_blueprint.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from .do_wrapper import _do_wrapper
 from .http import HTTPMethod
 from .models import Tag, Components
+from .types import OpenAPIResponsesType
 from .utils import get_openapi_path, get_operation, get_responses, parse_and_store_tags, parse_parameters, \
     validate_responses_type, parse_method, get_operation_id_for_path
 
@@ -24,7 +25,7 @@ class APIBlueprint(Blueprint):
             *,
             abp_tags: Optional[List[Tag]] = None,
             abp_security: Optional[List[Dict[str, List[str]]]] = None,
-            abp_responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            abp_responses: OpenAPIResponsesType = None,
             doc_ui: bool = True,
             **kwargs: Any
     ) -> None:
@@ -167,7 +168,7 @@ class APIBlueprint(Blueprint):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -223,7 +224,7 @@ class APIBlueprint(Blueprint):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -279,7 +280,7 @@ class APIBlueprint(Blueprint):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -335,7 +336,7 @@ class APIBlueprint(Blueprint):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -391,7 +392,7 @@ class APIBlueprint(Blueprint):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -19,6 +19,7 @@ from .models import Info, APISpec, Tag, Components, Server
 from .models.common import Reference, ExternalDocumentation
 from .models.oauth import OAuthConfig
 from .models.security import SecurityScheme
+from .types import OpenAPIResponsesType
 from .utils import get_openapi_path, get_operation, get_responses, parse_and_store_tags, parse_parameters, \
     validate_responses_type, parse_method, get_operation_id_for_path
 
@@ -31,7 +32,7 @@ class OpenAPI(Flask):
             info: Optional[Info] = None,
             security_schemes: Optional[Dict[str, Union[SecurityScheme, Reference]]] = None,
             oauth_config: Optional[OAuthConfig] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             doc_ui: bool = True,
             doc_expansion: str = "list",
             doc_prefix: str = "/openapi",
@@ -267,7 +268,7 @@ class OpenAPI(Flask):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -323,7 +324,7 @@ class OpenAPI(Flask):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -379,7 +380,7 @@ class OpenAPI(Flask):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -435,7 +436,7 @@ class OpenAPI(Flask):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,
@@ -491,7 +492,7 @@ class OpenAPI(Flask):
             tags: Optional[List[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
-            responses: Optional[Dict[str, Type[BaseModel]]] = None,
+            responses: OpenAPIResponsesType = None,
             extra_responses: Optional[Dict[str, dict]] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
             deprecated: Optional[bool] = None,

--- a/flask_openapi3/types.py
+++ b/flask_openapi3/types.py
@@ -1,0 +1,6 @@
+from typing import Optional, Dict, Type
+
+from pydantic import BaseModel
+
+
+OpenAPIResponsesType = Optional[Dict[str, Optional[Type[BaseModel]]]]

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -305,7 +305,7 @@ def get_responses(
 
         # Verify that if the key is "204", the response is None,
         # because http status code "204" means return "No Content"
-        elif key in ["204"] and response is None:
+        elif response is None:
             _responses[key] = Response(
                 description=HTTP_STATUS.get(key, ""),
             )

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -278,29 +278,41 @@ def get_responses(
     # if not responses.get("500"):
     #     _responses["500"] = Response(description=HTTP_STATUS["500"])
     # handle extra_responses
+
     for key, response in responses.items():
-        assert inspect.isclass(response) and \
-               issubclass(response, BaseModel), f" {response} is invalid `pydantic.BaseModel`"
-        schema = response.schema(ref_template=OPENAPI3_REF_TEMPLATE)
-        _responses[key] = Response(
-            description=HTTP_STATUS.get(key, ""),
-            content={
-                "application/json": MediaType(
-                    **{
-                        "schema": Schema(
-                            **{
-                                "$ref": f"{OPENAPI3_REF_PREFIX}/{response.__name__}"
-                            }
-                        )
-                    }
-                )
-            }
-        )
-        _schemas[response.__name__] = Schema(**schema)
-        definitions = schema.get('definitions')
-        if definitions:
-            for name, value in definitions.items():
-                _schemas[name] = Schema(**value)
+        # Verify that the response is a class and that class is a subclass of `pydantic.BaseModel`
+        if inspect.isclass(response) and issubclass(response, BaseModel):
+            schema = response.schema(ref_template=OPENAPI3_REF_TEMPLATE)
+            _responses[key] = Response(
+                description=HTTP_STATUS.get(key, ""),
+                content={
+                    "application/json": MediaType(
+                        **{
+                            "schema": Schema(
+                                **{
+                                    "$ref": f"{OPENAPI3_REF_PREFIX}/{response.__name__}"
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+            _schemas[response.__name__] = Schema(**schema)
+            definitions = schema.get('definitions')
+            if definitions:
+                for name, value in definitions.items():
+                    _schemas[name] = Schema(**value)
+
+        # Verify that if the key is "204", the response is None,
+        # because http status code "204" means return "No Content"
+        elif key in ["204"] and response is None:
+            _responses[key] = Response(
+                description=HTTP_STATUS.get(key, ""),
+            )
+
+        else:
+            raise AttributeError(f'{response} is invalid `pydantic.BaseModel` '
+                                 f'or if the key is "204" the type should be None')
     # handle extra_responses
     for key, value in extra_responses.items():
         # key "200" value {"content":{"text/csv":{"schema":{"type": "string"}}}}

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from flask_openapi3 import HTTPBearer
 from flask_openapi3 import Info, Tag
 from flask_openapi3 import OpenAPI
+from openapi_python_client import GeneratorData, Config
 
 info = Info(title='book API', version='1.0.0')
 security_schemes = {"jwt": HTTPBearer(bearerFormat="JWT")}
@@ -122,10 +123,16 @@ def update_book1(path: BookPath, body: BookBody):
     return {"code": 0, "message": "ok"}
 
 
-@app.delete('/book/<int:bid>', tags=[book_tag])
+@app.delete('/book/<int:bid>', tags=[book_tag], responses={"200": BaseResponse})
 def delete_book(path: BookPath):
     assert path.bid == 1
     return {"code": 0, "message": "ok"}
+
+
+@app.delete('/book_no_response/<int:bid>', tags=[book_tag], responses={"204": None})
+def delete_book_no_response(path: BookPath):
+    assert path.bid == 1
+    return b'', 204
 
 
 def test_openapi(client):
@@ -163,3 +170,25 @@ def test_patch(client):
 def test_delete(client):
     resp = client.delete("/book/1")
     assert resp.status_code == 200
+
+
+def test_delete_no_response(client):
+    resp = client.delete("/book_no_response/1")
+    assert resp.status_code == 204
+
+
+def test_openapi_api_json_schema_against_openapi_python_client_generator(client):
+    config = Config()
+
+    resp = client.get("/openapi/openapi.json")
+    assert resp.status_code == 200
+    openapi = GeneratorData.from_dict(data=resp.json, config=config)
+    assert type(openapi) == GeneratorData
+
+    assert "content" in resp.json["paths"]["/book/{bid}"]["delete"]["responses"]["200"]
+    assert "content" in resp.json["paths"]["/book/{bid}"]["delete"]["responses"]["404"]
+    assert "content" in resp.json["paths"]["/book/{bid}"]["delete"]["responses"]["422"]
+
+    assert "content" not in resp.json["paths"]["/book_no_response/{bid}"]["delete"]["responses"]["204"]
+    assert "content" in resp.json["paths"]["/book_no_response/{bid}"]["delete"]["responses"]["404"]
+    assert "content" in resp.json["paths"]["/book_no_response/{bid}"]["delete"]["responses"]["422"]


### PR DESCRIPTION
- Added support for [Empty Response Body](https://swagger.io/docs/specification/describing-responses/#empty)
- Created unittest for Empty Response Body
- Changed the `OpenAPIResponsesType` to allow the value of the dictionary to be `None`
- Added example for Empty Response Body

Checklist:
- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.
