### PR TITLE
Response List: Fixed bug - The code for validation responses can now handle `list`

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -353,8 +353,9 @@ def validate_response(resp: Any, responses: Dict[str, Type[BaseModel]]) -> None:
     assert inspect.isclass(resp_model) and \
            issubclass(resp_model, BaseModel), f"{resp_model} is invalid `pydantic.BaseModel`"
     try:
-        if len(resp_model.__fields__) == 1 and isinstance(_resp, list):
-            resp_model(**{list(resp_model.__fields__.keys())[0]: _resp})
+        if resp_model.__custom_root_type__:
+            # https://pydantic-docs.helpmanual.io/usage/models/#custom-root-types
+            resp_model(__root__=_resp)
         else:
             resp_model(**_resp)
     except TypeError:

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -353,7 +353,10 @@ def validate_response(resp: Any, responses: Dict[str, Type[BaseModel]]) -> None:
     assert inspect.isclass(resp_model) and \
            issubclass(resp_model, BaseModel), f"{resp_model} is invalid `pydantic.BaseModel`"
     try:
-        resp_model(**_resp)
+        if len(resp_model.__fields__) == 1 and isinstance(_resp, list):
+            resp_model(**{list(resp_model.__fields__.keys())[0]: _resp})
+        else:
+            resp_model(**_resp)
     except TypeError:
         raise TypeError(f"`{resp_model.__name__}` validation failed, must be a mapping.")
 


### PR DESCRIPTION
I run into a bug when writing unittests there validated the returned JSON-object which contains a `list`.

I created 2 unittests to verify that my bug fix works :D

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.
