### PR TITLE
extra_responses allow to provide description, links, headers and (additional) content

### DIFF
--- a/flask_openapi3/models/common.py
+++ b/flask_openapi3/models/common.py
@@ -63,8 +63,3 @@ class Encoding(BaseModel):
 class MediaType(BaseModel):
     schema_: Optional[Union[Schema, Reference]] = Field(None, alias="schema")
     encoding: Optional[Dict[str, Encoding]] = None
-
-
-class Response(BaseModel):
-    description: Optional[str]
-    content: Optional[Dict[str, MediaType]] = None

--- a/flask_openapi3/models/server.py
+++ b/flask_openapi3/models/server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2021/4/28 11:26
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Any
 
 from pydantic import BaseModel
 
@@ -16,3 +16,12 @@ class Server(BaseModel):
     url: str
     description: Optional[str] = None
     variables: Optional[Dict[str, ServerVariable]] = None
+
+
+class Link(BaseModel):
+    operationRef: Optional[str] = None
+    operationId: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    requestBody: Optional[Any] = None
+    description: Optional[str] = None
+    server: Optional[Server] = None

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from flask_openapi3 import OpenAPI
+
+
+def test_extra_responses_are_replicated_in_open_api(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.get(
+        '/test',
+        extra_responses={
+            "201": {
+                "description": "Custom description",
+                "headers": {
+                    "location": {
+                        "description": "URL of the new resource",
+                        "schema": {"type": "string"}
+                    }
+                },
+                "links": {
+                    "dummy": {
+                        "description": "dummy link"
+                    }
+                }
+            }
+        }
+    )
+    def endpoint_test():
+        return b'', 201
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["get"]["responses"]["201"] == {
+            "description": "Custom description",
+            "headers": {
+                "location": {
+                    "description": "URL of the new resource",
+                    "schema": {"type": "string"}
+                }
+            },
+            "links": {
+                "dummy": {
+                    "description": "dummy link"
+                }
+            }
+        }
+

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,9 +1,187 @@
 from __future__ import annotations
 
+from pydantic import BaseModel
+
 from flask_openapi3 import OpenAPI
 
 
+def test_responses_and_extra_responses_are_replicated_in_open_api(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    class BaseResponse(BaseModel):
+        """Base description"""
+        test: int
+
+    @test_app.get(
+        '/test',
+        responses={"201": BaseResponse},
+        extra_responses={
+            "201": {
+                "description": "Custom description",
+                "headers": {
+                    "location": {
+                        "description": "URL of the new resource",
+                        "schema": {"type": "string"}
+                    }
+                },
+                "content": {
+                    "text/plain": {
+                        "schema": {"type": "string"}
+                    }
+                },
+                "links": {
+                    "dummy": {
+                        "description": "dummy link"
+                    }
+                }
+            }
+        }
+    )
+    def endpoint_test():
+        return b'', 201
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["get"]["responses"]["201"] == {
+            "description": "Custom description",
+            "headers": {
+                "location": {
+                    "description": "URL of the new resource",
+                    "schema": {"type": "string"}
+                }
+            },
+            "content": {
+                # This content is coming from responses
+                'application/json': {
+                    'schema': {'$ref': '#/components/schemas/BaseResponse'}
+                },
+                # While this one comes from extra_responses
+                "text/plain": {
+                    "schema": {"type": "string"}
+                }
+            },
+            "links": {
+                "dummy": {
+                    "description": "dummy link"
+                }
+            }
+        }
+
+
+def test_none_responses_and_extra_responses_are_replicated_in_open_api(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.get(
+        '/test',
+        responses={"204": None},
+        extra_responses={
+            "204": {
+                "description": "Custom description",
+                "headers": {
+                    "x-my-special-header": {
+                        "description": "Custom header",
+                        "schema": {"type": "string"}
+                    }
+                },
+                "content": {
+                    "text/plain": {
+                        "schema": {"type": "string"}
+                    }
+                },
+                "links": {
+                    "dummy": {
+                        "description": "dummy link"
+                    }
+                }
+            }
+        }
+    )
+    def endpoint_test():
+        return b'', 204
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["get"]["responses"]["204"] == {
+            "description": "Custom description",
+            "headers": {
+                "x-my-special-header": {
+                    "description": "Custom header",
+                    "schema": {"type": "string"}
+                }
+            },
+            "content": {
+                "text/plain": {
+                    "schema": {"type": "string"}
+                }
+            },
+            "links": {
+                "dummy": {
+                    "description": "dummy link"
+                }
+            }
+        }
+
+
 def test_extra_responses_are_replicated_in_open_api(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.get(
+        '/test',
+        extra_responses={
+            "201": {
+                "description": "Custom description",
+                "headers": {
+                    "location": {
+                        "description": "URL of the new resource",
+                        "schema": {"type": "string"}
+                    }
+                },
+                "content": {
+                    "text/plain": {
+                        "schema": {"type": "string"}
+                    }
+                },
+                "links": {
+                    "dummy": {
+                        "description": "dummy link"
+                    }
+                }
+            }
+        }
+    )
+    def endpoint_test():
+        return b'', 201
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["get"]["responses"]["201"] == {
+            "description": "Custom description",
+            "headers": {
+                "location": {
+                    "description": "URL of the new resource",
+                    "schema": {"type": "string"}
+                }
+            },
+            "content": {
+                "text/plain": {
+                    "schema": {"type": "string"}
+                }
+            },
+            "links": {
+                "dummy": {
+                    "description": "dummy link"
+                }
+            }
+        }
+
+
+def test_extra_responses_without_content_are_replicated_in_open_api(request):
     test_app = OpenAPI(request.node.name)
     test_app.config["TESTING"] = True
 
@@ -46,4 +224,3 @@ def test_extra_responses_are_replicated_in_open_api(request):
                 }
             }
         }
-


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.

Note that I had to move Response model class to another file due to dependencies on sub models. EVen if it's public, I expect it to be without impact as it is not documented, so it should not be used.

fixes #35 