### PR TITLE
add support for overriding swagger UI rendering

### DIFF
--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -69,6 +69,14 @@ class OpenAPI(APIScaffold, Flask):
                            See: https://spec.openapis.org/oas/v3.0.3#external-documentation-object
             **kwargs: Flask kwargs
         """
+
+        # build app_config from kwargs -- this permits overriding some default view behavior such as
+        # favicon or whether to render the top bar
+        self._app_config = dict()
+        self._app_config['ui_hide_top_bar'] = kwargs.pop('ui_hide_top_bar', False) is True
+        self._app_config['ui_favicon'] = kwargs.pop('ui_favicon', "static/images/swagger.svg")
+        self._app_config['ui_title'] = kwargs.pop('ui_title', "Swagger UI")
+
         super(OpenAPI, self).__init__(import_name, **kwargs)
 
         self.openapi_version = "3.0.3"
@@ -127,7 +135,8 @@ class OpenAPI(APIScaffold, Flask):
                 "swagger.html",
                 api_doc_url=self.api_doc_url.lstrip("/"),
                 doc_expansion=self.doc_expansion,
-                oauth_config=self.oauth_config.dict() if self.oauth_config else None
+                oauth_config=self.oauth_config.dict() if self.oauth_config else None,
+                app_config=self._app_config
             )
         )
         blueprint.add_url_rule(

--- a/flask_openapi3/templates/swagger.html
+++ b/flask_openapi3/templates/swagger.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Swagger UI</title>
-    <link rel="shortcut icon" href="static/images/swagger.svg">
+    <title>{{ app_config.ui_title }}</title>
+    <link rel="shortcut icon" href="{{ app_config.ui_favicon }}">
     <link rel="stylesheet" type="text/css" href="static/css/swagger-ui.css">
     <style>
         html {
@@ -40,7 +40,9 @@
             plugins: [
                 SwaggerUIBundle.plugins.DownloadUrl
             ],
+            {% if not app_config.ui_hide_top_bar -%}
             layout: "StandaloneLayout",
+            {%- endif %}
             docExpansion: "{{ doc_expansion }}"
         })
         // End Swagger UI call region

--- a/tests/test_ui_options.py
+++ b/tests/test_ui_options.py
@@ -37,4 +37,3 @@ def test_get(client):
 
     if app._app_config.get('ui_hide_top_bar'):
         assert 'layout: "StandaloneLayout"' not in data
-

--- a/tests/test_ui_options.py
+++ b/tests/test_ui_options.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# @Author  : bkl
+# @Time    : 2023/12/18 9:23
+
+import pytest
+from pydantic import BaseModel, Extra
+
+from flask_openapi3 import Info, OpenAPI
+
+info = Info(title='book API', version='1.0.0')
+
+# apply optional `ui_hide_top_bar`, `ui_favicon`, `ui_title`
+app = OpenAPI(
+    __name__, info=info,
+    ui_hide_top_bar=True,
+    ui_favicon='/static/myfavicon.ico',
+    ui_title='my title test'
+)
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+def test_get(client):
+    print(app._app_config)
+    resp = client.get("/openapi/swagger")
+    data = str(resp.data)
+    # print(data)
+    assert resp.status_code == 200
+    assert 'rel="shortcut icon" href="{}"'.format(app._app_config.get('ui_favicon')) in data
+    assert '<title>{}'.format(app._app_config.get('ui_title')) in data
+
+    if app._app_config.get('ui_hide_top_bar'):
+        assert 'layout: "StandaloneLayout"' not in data
+

--- a/tests/test_ui_options.py
+++ b/tests/test_ui_options.py
@@ -3,7 +3,6 @@
 # @Time    : 2023/12/18 9:23
 
 import pytest
-from pydantic import BaseModel, Extra
 
 from flask_openapi3 import Info, OpenAPI
 


### PR DESCRIPTION
Adds support for overriding a few swagger.html components.
* favicon
* page title
* whether to render the top bar
