### PR TITLE
Correct link

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 
 *New in v2.2.0*
 
-Class-based API View, click [here](https://github.com/luolingchun/flask-openapi3/blob/APIView/examples/api_view_demo.py) go to the complete example:
+Class-based API View, click [here](https://github.com/luolingchun/flask-openapi3/blob/master/examples/api_view_demo.py) go to the complete example:
 
 ```python
 @api_view.route("/book")

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 
 *New in v2.2.0*
 
-Class-based API View, click [here](https://github.com/luolingchun/flask-openapi3/blob/master/examples/api_view_demo.py) go to the complete example:
+Class-based API View, click [here](https://github.com/luolingchun/flask-openapi3/blob/master/examples/api_view_demo.py) for the complete example:
 
 ```python
 @api_view.route("/book")


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.


This PR fixed the link to the complete example of Class-based API View. The link I provided may not be the best, but it is definitely better than the existing one. Additionally, I also provided some rewording.