### PR TITLE
feat: Add operation_id_callback to v1.x

### DIFF
--- a/flask_openapi3/api_blueprint.py
+++ b/flask_openapi3/api_blueprint.py
@@ -41,7 +41,7 @@ class APIBlueprint(Blueprint):
             abp_responses: APIBlueprint response model
             doc_ui: add openapi document UI(swagger and redoc). Defaults to True.
             operation_id_callback: Callback function for custom operation_id generation.
-                Receives function_name (str), request_path (str) and request_method (str) parameters.
+                Receives name (str), path (str) and method (str) parameters.
                 Defaults to `get_operation_id_for_path` from utils
             kwargs: Flask Blueprint kwargs
         """

--- a/flask_openapi3/api_blueprint.py
+++ b/flask_openapi3/api_blueprint.py
@@ -26,6 +26,7 @@ class APIBlueprint(Blueprint):
             abp_security: Optional[List[Dict[str, List[str]]]] = None,
             abp_responses: Optional[Dict[str, Type[BaseModel]]] = None,
             doc_ui: bool = True,
+            operation_id_callback: Callable = get_operation_id_for_path,
             **kwargs: Any
     ) -> None:
         """
@@ -39,6 +40,9 @@ class APIBlueprint(Blueprint):
             abp_security: APIBlueprint security for every api
             abp_responses: APIBlueprint response model
             doc_ui: add openapi document UI(swagger and redoc). Defaults to True.
+            operation_id_callback: Callback function for custom operation_id generation.
+                Receives function_name (str), request_path (str) and request_method (str) parameters.
+                Defaults to `get_operation_id_for_path` from utils
             kwargs: Flask Blueprint kwargs
         """
         super(APIBlueprint, self).__init__(name, import_name, **kwargs)
@@ -52,6 +56,7 @@ class APIBlueprint(Blueprint):
         self.abp_security = abp_security or []
         self.abp_responses = abp_responses or {}
         self.doc_ui = doc_ui
+        self.operation_id_callback: Callable = operation_id_callback
 
     def _do_decorator(
             self,
@@ -112,10 +117,9 @@ class APIBlueprint(Blueprint):
             if deprecated:
                 operation.deprecated = True
             # Unique string used to identify the operation.
-            if operation_id:
-                operation.operationId = operation_id
-            else:
-                operation.operationId = get_operation_id_for_path(name=func.__name__, path=rule, method=method)
+            operation.operationId = operation_id or self.operation_id_callback(
+                name=func.__name__, path=rule, method=method
+            )
             # store tags
             tags = tags + self.abp_tags if tags else self.abp_tags
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -67,7 +67,7 @@ class OpenAPI(Flask):
             rapidoc_url: The RapiDoc UI documentation. Defaults to `/rapidoc`.
             servers: An array of Server Objects, which provide connectivity information to a target server.
             operation_id_callback: Callback function for custom operation_id generation.
-                          Receives function_name (str), request_path (str) and request_method (str) parameters.
+                          Receives name (str), path (str) and method (str) parameters.
                           Defaults to `get_operation_id_for_path` from utils
             kwargs: Flask kwargs
         """

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -41,6 +41,7 @@ class OpenAPI(Flask):
             redoc_url: str = "/redoc",
             rapidoc_url: str = "/rapidoc",
             servers: Optional[List[Server]] = None,
+            operation_id_callback: Callable = get_operation_id_for_path,
             **kwargs: Any
     ) -> None:
         """
@@ -65,6 +66,9 @@ class OpenAPI(Flask):
             redoc_url: The Redoc UI documentation. Defaults to `/redoc`.
             rapidoc_url: The RapiDoc UI documentation. Defaults to `/rapidoc`.
             servers: An array of Server Objects, which provide connectivity information to a target server.
+            operation_id_callback: Callback function for custom operation_id generation.
+                          Receives function_name (str), request_path (str) and request_method (str) parameters.
+                          Defaults to `get_operation_id_for_path` from utils
             kwargs: Flask kwargs
         """
         super(OpenAPI, self).__init__(import_name, **kwargs)
@@ -94,6 +98,7 @@ class OpenAPI(Flask):
             self.init_doc()
         self.doc_expansion = doc_expansion
         self.severs = servers
+        self.operation_id_callback: Callable = operation_id_callback
 
     def init_doc(self) -> None:
         """
@@ -254,10 +259,9 @@ class OpenAPI(Flask):
             if deprecated:
                 operation.deprecated = True
             # Unique string used to identify the operation.
-            if operation_id:
-                operation.operationId = operation_id
-            else:
-                operation.operationId = get_operation_id_for_path(name=func.__name__, path=rule, method=method)
+            operation.operationId = operation_id or self.operation_id_callback(
+                name=func.__name__, path=rule, method=method
+            )
             # store tags
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)
             # parse parameters

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -86,6 +86,8 @@ def test_openapi(client):
     resp = client.get("/openapi/openapi.json")
     assert resp.status_code == 200
     assert resp.json == app.api_doc
+    assert resp.json["paths"]["/api/book/{bid}"]["put"]["operationId"] == "update"
+    assert resp.json["paths"]["/api/book/{bid}"]["delete"]["operationId"] == "delete_book_book__int_bid__delete"
 
 
 def test_post(client):


### PR DESCRIPTION
Resolves #67 
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed. -> `v1.x` version isn't configured with mypy
