### PR TITLE
Init view_class and pass kw/args

### DIFF
--- a/flask_openapi3/__init__.py
+++ b/flask_openapi3/__init__.py
@@ -47,5 +47,4 @@ from .models.server import ServerVariable
 from .models.tag import Tag
 from .models.validation_error import UnprocessableEntity
 from .openapi import OpenAPI
-from .openapi import MethodView
 from .view import APIView

--- a/flask_openapi3/__init__.py
+++ b/flask_openapi3/__init__.py
@@ -47,4 +47,5 @@ from .models.server import ServerVariable
 from .models.tag import Tag
 from .models.validation_error import UnprocessableEntity
 from .openapi import OpenAPI
+from .openapi import MethodView
 from .view import APIView

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -182,15 +182,23 @@ class OpenAPI(APIScaffold, Flask):
         self.components_schemas.update(**api.components_schemas)
         self.register_blueprint(api)
 
-    def register_api_view(self, api_view: APIView, view_args=[], view_kwargs={}) -> None:
-        """Register APIView"""
+    def register_api_view(self, api_view: APIView, view_kwargs: Dict[Any, Any] = None) -> None:
+        """
+        Register APIView
+
+        Arguments:
+            api_view: APIView
+            view_kwargs: extra view kwargs
+        """
+        if view_kwargs is None:
+            view_kwargs = {}
         for tag in api_view.tags:
             if tag.name not in self.tag_names:
                 self.tags.append(tag)
                 self.tag_names.append(tag.name)
         self.paths.update(**api_view.paths)
         self.components_schemas.update(**api_view.components_schemas)
-        api_view.register(self, view_args=view_args, view_kwargs=view_kwargs)
+        api_view.register(self, view_kwargs=view_kwargs)
 
     def _do_decorator(
             self,

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from typing import Optional, List, Dict, Union, Any, Type, Callable, Tuple
 
 from flask import Flask, Blueprint, render_template_string
-from flask.views import MethodView as FlaskMethodView
 from pydantic import BaseModel
 
 from .blueprint import APIBlueprint
@@ -24,9 +23,6 @@ from .utils import get_operation, get_responses, parse_and_store_tags, parse_par
     get_operation_id_for_path
 from .view import APIView
 
-
-class MethodView(FlaskMethodView):
-    pass
 
 class OpenAPI(APIScaffold, Flask):
     def __init__(
@@ -186,7 +182,7 @@ class OpenAPI(APIScaffold, Flask):
         self.components_schemas.update(**api.components_schemas)
         self.register_blueprint(api)
 
-    def register_api_view(self, api_view: APIView, view_class_kwargs= {}) -> None:
+    def register_api_view(self, api_view: APIView, view_args=[], view_kwargs={}) -> None:
         """Register APIView"""
         for tag in api_view.tags:
             if tag.name not in self.tag_names:
@@ -194,7 +190,7 @@ class OpenAPI(APIScaffold, Flask):
                 self.tag_names.append(tag.name)
         self.paths.update(**api_view.paths)
         self.components_schemas.update(**api_view.components_schemas)
-        api_view.register(self, view_class_kwargs=view_class_kwargs)
+        api_view.register(self, view_args=view_args, view_kwargs=view_kwargs)
 
     def _do_decorator(
             self,

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -182,7 +182,7 @@ class OpenAPI(APIScaffold, Flask):
         self.components_schemas.update(**api.components_schemas)
         self.register_blueprint(api)
 
-    def register_api_view(self, api_view: APIView, view_kwargs: Dict[Any, Any] = None) -> None:
+    def register_api_view(self, api_view: APIView, view_kwargs: Optional[Dict[Any, Any]] = None) -> None:
         """
         Register APIView
 

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import Optional, List, Dict, Union, Any, Type, Callable, Tuple
 
 from flask import Flask, Blueprint, render_template_string
+from flask.views import MethodView as FlaskMethodView
 from pydantic import BaseModel
 
 from .blueprint import APIBlueprint
@@ -23,6 +24,9 @@ from .utils import get_operation, get_responses, parse_and_store_tags, parse_par
     get_operation_id_for_path
 from .view import APIView
 
+
+class MethodView(FlaskMethodView):
+    pass
 
 class OpenAPI(APIScaffold, Flask):
     def __init__(
@@ -182,7 +186,7 @@ class OpenAPI(APIScaffold, Flask):
         self.components_schemas.update(**api.components_schemas)
         self.register_blueprint(api)
 
-    def register_api_view(self, api_view: APIView) -> None:
+    def register_api_view(self, api_view: APIView, view_class_kwargs= {}) -> None:
         """Register APIView"""
         for tag in api_view.tags:
             if tag.name not in self.tag_names:
@@ -190,7 +194,7 @@ class OpenAPI(APIScaffold, Flask):
                 self.tag_names.append(tag.name)
         self.paths.update(**api_view.paths)
         self.components_schemas.update(**api_view.components_schemas)
-        api_view.register(self)
+        api_view.register(self, view_class_kwargs=view_class_kwargs)
 
     def _do_decorator(
             self,

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -59,7 +59,7 @@ class APIScaffold(Scaffold, ABC):
         raise NotImplementedError
 
     @staticmethod
-    def create_view_func(func, header, cookie, path, query, form, body, view_class=None):
+    def create_view_func(func, header, cookie, path, query, form, body, view_class=None, view_class_kwargs={}):
         is_coroutine_function = iscoroutinefunction(func)
         if is_coroutine_function:
             @wraps(func)
@@ -78,7 +78,10 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle async request
                 if view_class:
-                    response = await func(view_class, **result)
+                    view_fn = view_class.as_view(
+                        view_class.__name__.lower(), **view_class_kwargs
+                    )
+                    response = await view_fn(**result)
                 else:
                     response = await func(**result)
                 return response
@@ -99,7 +102,10 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle request
                 if view_class:
-                    response = func(view_class, **result)
+                    view_fn = view_class.as_view(
+                        view_class.__name__.lower(), **view_class_kwargs
+                    )
+                    response = view_fn(**result)
                 else:
                     response = func(**result)
                 return response

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -68,7 +68,7 @@ class APIScaffold(Scaffold, ABC):
             form,
             body,
             view_class=None,
-            view_kwargs: Dict[Any, Any] = None
+            view_kwargs=None
     ):
         is_coroutine_function = iscoroutinefunction(func)
         if is_coroutine_function:

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -59,7 +59,18 @@ class APIScaffold(Scaffold, ABC):
         raise NotImplementedError
 
     @staticmethod
-    def create_view_func(func, header, cookie, path, query, form, body, view_class=None, view_class_kwargs={}):
+    def create_view_func(
+        func,
+        header,
+        cookie,
+        path,
+        query,
+        form,
+        body,
+        view_class=None,
+        view_args=[],
+        view_kwargs={}
+    ):
         is_coroutine_function = iscoroutinefunction(func)
         if is_coroutine_function:
             @wraps(func)
@@ -78,10 +89,8 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle async request
                 if view_class:
-                    view_fn = view_class.as_view(
-                        view_class.__name__.lower(), **view_class_kwargs
-                    )
-                    response = await view_fn(**result)
+                    view_object = view_class(*view_args, **view_kwargs)
+                    response = await func(view_object, **result)
                 else:
                     response = await func(**result)
                 return response
@@ -102,10 +111,8 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle request
                 if view_class:
-                    view_fn = view_class.as_view(
-                        view_class.__name__.lower(), **view_class_kwargs
-                    )
-                    response = view_fn(**result)
+                    view_object = view_class(*view_args, **view_kwargs)
+                    response = func(view_object, **result)
                 else:
                     response = func(**result)
                 return response

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -60,16 +60,15 @@ class APIScaffold(Scaffold, ABC):
 
     @staticmethod
     def create_view_func(
-        func,
-        header,
-        cookie,
-        path,
-        query,
-        form,
-        body,
-        view_class=None,
-        view_args=[],
-        view_kwargs={}
+            func,
+            header,
+            cookie,
+            path,
+            query,
+            form,
+            body,
+            view_class=None,
+            view_kwargs: Dict[Any, Any] = None
     ):
         is_coroutine_function = iscoroutinefunction(func)
         if is_coroutine_function:
@@ -89,7 +88,12 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle async request
                 if view_class:
-                    view_object = view_class(*view_args, **view_kwargs)
+                    signature = inspect.signature(view_class.__init__)
+                    parameters = signature.parameters
+                    if parameters.get("view_kwargs"):
+                        view_object = view_class(view_kwargs=view_kwargs)
+                    else:
+                        view_object = view_class()
                     response = await func(view_object, **result)
                 else:
                     response = await func(**result)
@@ -111,7 +115,12 @@ class APIScaffold(Scaffold, ABC):
                     return result
                 # handle request
                 if view_class:
-                    view_object = view_class(*view_args, **view_kwargs)
+                    signature = inspect.signature(view_class.__init__)
+                    parameters = signature.parameters
+                    if parameters.get("view_kwargs"):
+                        view_object = view_class(view_kwargs=view_kwargs)
+                    else:
+                        view_object = view_class()
                     response = func(view_object, **result)
                 else:
                     response = func(**result)

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -177,12 +177,12 @@ class APIView:
 
         return decorator
 
-    def register(self, app: "OpenAPI"):
+    def register(self, app: "OpenAPI", view_class_kwargs: dict = None):
         for rule, (cls, methods) in self.views.items():
             for method in methods:
                 func = getattr(cls, method.lower())
                 header, cookie, path, query, form, body = parse_parameters(func, doc_ui=False)
-                view_func = app.create_view_func(func, header, cookie, path, query, form, body, view_class=cls)
+                view_func = app.create_view_func(func, header, cookie, path, query, form, body, view_class=cls, view_class_kwargs=view_class_kwargs)
                 options = {
                     "endpoint": cls.__name__ + "." + method.lower(),
                     "methods": [method.upper()]

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -177,7 +177,9 @@ class APIView:
 
         return decorator
 
-    def register(self, app: "OpenAPI", view_args: List[Any] = [], view_kwargs: Dict[str, Any] = {}):
+    def register(self, app: "OpenAPI", view_kwargs: Dict[Any, Any] = None):
+        if view_kwargs is None:
+            view_kwargs = {}
         for rule, (cls, methods) in self.views.items():
             for method in methods:
                 func = getattr(cls, method.lower())
@@ -191,7 +193,6 @@ class APIView:
                     form,
                     body,
                     view_class=cls,
-                    view_args=view_args,
                     view_kwargs=view_kwargs
                 )
                 options = {

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -177,12 +177,23 @@ class APIView:
 
         return decorator
 
-    def register(self, app: "OpenAPI", view_class_kwargs: dict = None):
+    def register(self, app: "OpenAPI", view_args: List[Any] = [], view_kwargs: Dict[str, Any] = {}):
         for rule, (cls, methods) in self.views.items():
             for method in methods:
                 func = getattr(cls, method.lower())
                 header, cookie, path, query, form, body = parse_parameters(func, doc_ui=False)
-                view_func = app.create_view_func(func, header, cookie, path, query, form, body, view_class=cls, view_class_kwargs=view_class_kwargs)
+                view_func = app.create_view_func(
+                    func,
+                    header,
+                    cookie,
+                    path,
+                    query,
+                    form,
+                    body,
+                    view_class=cls,
+                    view_args=view_args,
+                    view_kwargs=view_kwargs
+                )
                 options = {
                     "endpoint": cls.__name__ + "." + method.lower(),
                     "methods": [method.upper()]

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -177,7 +177,7 @@ class APIView:
 
         return decorator
 
-    def register(self, app: "OpenAPI", view_kwargs: Dict[Any, Any] = None):
+    def register(self, app: "OpenAPI", view_kwargs: Optional[Dict[Any, Any]] = None):
         if view_kwargs is None:
             view_kwargs = {}
         for rule, (cls, methods) in self.views.items():

--- a/tests/test_api_view_args.py
+++ b/tests/test_api_view_args.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2022/11/4 14:41
+
+import pytest
+
+from flask_openapi3 import APIView
+from flask_openapi3 import OpenAPI
+
+TEST_NUMBER = 3
+TEST_KWARG = "test"
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+api_view = APIView(url_prefix="/api/v1")
+
+
+@api_view.route("/book")
+class BookListAPIView:
+    def __init__(self, number, kwarg=None):
+        self.number = number
+        self.kwarg = kwarg
+
+    @api_view.doc(summary="get book list")
+    def get(self):
+        return {"number": self.number, "kwarg": self.kwarg}
+
+
+app.register_api_view(api_view, view_args=[TEST_NUMBER], view_kwargs={"kwarg": TEST_KWARG})
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+def test_get_list_view_args(client):
+    resp = client.get("/api/v1/book")
+    assert resp.status_code == 200
+
+    assert resp.json["number"] == TEST_NUMBER
+    assert resp.json["kwarg"] == TEST_KWARG


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mkdocs serve` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.

This is a wip, should close https://github.com/luolingchun/flask-openapi3/issues/66
I'll come back to the checklist shortly, i'm open to discussion on whether this is remotely the correct way to approach this problem!

~~I noticed that the view_class was never actually instantiated, if you inherit from `flask.views.MethodView` you can call `as_view` which deals with the class view instantiation automatically.~~

I stole this mostly from:
https://github.com/flask-restful/flask-restful/blob/b52b18807d2bbde0075bfc4f851161c1454c5368/flask_restful/__init__.py#L437

~~flasks `as_view`:
https://github.com/pallets/flask/blob/9659b11a45281662c6aa1194dc95b46b1f566ba6/src/flask/views.py#L85~~

basic usage:
```
@api_view.route("/test")
class List:
    def __init__(self, test=None):
        print("init List", test)

    @api_view.doc(summary="test list", responses={"200": ListModel})
    def get(self, query: ListQuery):
        print("Get", query)
        return {"moo": 1}

app.register_api_view(api_view, view_kwargs={"test": 1})
```