### PR TITLE
[#79] Support `by_alias` in Model Config

### DIFF
--- a/docs/Usage/Model_Config.md
+++ b/docs/Usage/Model_Config.md
@@ -106,3 +106,17 @@ class Message(BaseModel):
 Effect in swagger:
 
 ![](../assets/Snipaste_2023-06-02_11-08-40.png)
+
+
+## by_alias
+
+Sometimes you may not want to use aliases (such as in the responses model). In that case, `by_alias` will be convenient:
+
+```python
+class MessageResponse(BaseModel):
+    message: str = Field(..., description="The message")
+    metadata: Dict[str, str] = Field(alias="metadata_")
+
+    class Config:
+        by_alias = False
+```

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2023/6/30 10:12
+from typing import List, Dict
+
+import pytest
+from pydantic import BaseModel, Field
+
+from flask_openapi3 import OpenAPI, FileStorage
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+
+class UploadFilesForm(BaseModel):
+    file: FileStorage
+    str_list: List[str]
+
+    class Config:
+        openapi_extra = {
+            # "example": {"a": 123},
+            "examples": {
+                "Example 01": {
+                    "summary": "An example",
+                    "value": {
+                        "file": "Example-01.jpg",
+                        "str_list": ["a", "b", "c"]
+                    }
+                },
+                "Example 02": {
+                    "summary": "Another example",
+                    "value": {
+                        "str_list": ["1", "2", "3"]
+                    }
+                }
+            }
+        }
+
+
+class BookBody(BaseModel):
+    age: int
+    author: str
+
+    class Config:
+        openapi_extra = {
+            "description": "This is post RequestBody",
+            "example": {"age": 12, "author": "author1"},
+            "examples": {
+                "example1": {
+                    "summary": "example summary1",
+                    "description": "example description1",
+                    "value": {
+                        "age": 24,
+                        "author": "author2"
+                    }
+                },
+                "example2": {
+                    "summary": "example summary2",
+                    "description": "example description2",
+                    "value": {
+                        "age": 48,
+                        "author": "author3"
+                    }
+                }
+
+            }}
+
+
+class MessageResponse(BaseModel):
+    message: str = Field(..., description="The message")
+    metadata: Dict[str, str] = Field(alias="metadata_")
+
+    class Config:
+        by_alias = False
+        openapi_extra = {
+            # "example": {"message": "aaa"},
+            "examples": {
+                "example1": {
+                    "summary": "example1 summary",
+                    "value": {
+                        "message": "bbb"
+                    }
+                },
+                "example2": {
+                    "summary": "example2 summary",
+                    "value": {
+                        "message": "ccc"
+                    }
+                }
+            }
+        }
+
+
+@app.post("/form")
+def api_form(form: UploadFilesForm):
+    print(form)
+    return {"code": 0, "message": "ok"}
+
+
+@app.post("/body", responses={"200": MessageResponse})
+def api_error_json(body: BookBody):
+    print(body)
+    return {"code": 0, "message": "ok"}
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    _json = resp.json
+    assert resp.status_code == 200
+    assert _json["paths"]["/form"]["post"]["requestBody"]["content"]["multipart/form-data"]["examples"] == \
+           {
+               "Example 01": {
+                   "summary": "An example",
+                   "value": {
+                       "file": "Example-01.jpg",
+                       "str_list": ["a", "b", "c"]
+                   }
+               },
+               "Example 02": {
+                   "summary": "Another example",
+                   "value": {
+                       "str_list": ["1", "2", "3"]
+                   }
+               }
+           }
+    assert _json["paths"]["/body"]["post"]["requestBody"]["description"] == "This is post RequestBody"
+    assert _json["paths"]["/body"]["post"]["requestBody"]["content"]["application/json"]["example"] == \
+           {"age": 12, "author": "author1"}
+    assert _json["paths"]["/body"]["post"]["responses"]["200"]["content"]["application/json"]["examples"] == \
+           {
+               "example1": {
+                   "summary": "example1 summary",
+                   "value": {
+                       "message": "bbb"
+                   }
+               },
+               "example2": {
+                   "summary": "example2 summary",
+                   "value": {
+                       "message": "ccc"
+                   }
+               }
+           }
+    assert _json["components"]["schemas"]["MessageResponse"]["properties"].get("metadata") is not None


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

```python
class BookQuery(BaseModel):
    age: int
    author: str
    metadata: Dict[str, str] = Field(alias='metadata_')

    class Config:
        by_alias = False

    # in pydantic v2.x
    # model_config = ConfigDict(by_alias=False)
```
With `by_alias = False`:

![image](https://github.com/luolingchun/flask-openapi3/assets/22740403/028111b8-a804-4706-90a5-db5583808f27)

Without:

![image](https://github.com/luolingchun/flask-openapi3/assets/22740403/b494616c-a404-4ba8-9a05-e8839c9cfe31)


