### PR TITLE
ignore invalid properites for OpenAPI 3

### DIFF
--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -53,5 +53,5 @@ class Schema(BaseModel):
     example: Optional[Any] = None
     deprecated: Optional[bool] = None
 
-    class Config:
-        extra = "allow"
+    # this repository use Schema Object as Reference Object so we need $ref fieald
+    ref: Optional[str] = Field(alias="$ref", default=None)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -313,8 +313,10 @@ def test_form_examples(request):
             "required": True
         }
 
+
 class BaseRequestBody(BaseModel):
     base: BaseRequest
+
 
 def test_body_with_complex_object(request):
     test_app = OpenAPI(request.node.name)
@@ -327,4 +329,5 @@ def test_body_with_complex_object(request):
     with test_app.test_client() as client:
         resp = client.get("/openapi/openapi.json")
         assert resp.status_code == 200
-        assert set(["properties", "required", "title", "type"]) == set(resp.json['components']['schemas']['BaseRequestBody'].keys())
+        assert set(["properties", "required", "title", "type"]) == set(
+            resp.json['components']['schemas']['BaseRequestBody'].keys())

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -312,3 +312,19 @@ def test_form_examples(request):
             },
             "required": True
         }
+
+class BaseRequestBody(BaseModel):
+    base: BaseRequest
+
+def test_body_with_complex_object(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.post("/test")
+    def endpoint_test(body: BaseRequestBody):
+        return body.json(), 200
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert set(["properties", "required", "title", "type"]) == set(resp.json['components']['schemas']['BaseRequestBody'].keys())


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

# summary
This library generate broken OpenAPI 3 definitions when we have Schema Object in Request Body Object.
This change ignore invalid properties to fix broken definitions.


# bug detail
For example, we have this endpoint and use thease classes.

```python
class BaseRequest(BaseModel):
    test_int: int
    test_str: str

class BaseRequestBody(BaseModel):
    base: BaseRequest

@test_app.post("/test")
def endpoint_test(body: BaseRequestBody):
	return body.json(), 200
```

The OpenAPI 3 schema should be like this
```yaml
BaseRequestBody:
  title: BaseRequestBody
  required: ["base"]
  type: schema
  properties:
    $ref: "#/components/schemas/BaseRequest"
```

But we get schema with `definitions` or `$defs` porperty
```yaml
BaseRequestBody:
  title: BaseRequestBody
  required: ["base"]
  type: schema
  properties:
    $ref: "#/components/schemas/BaseRequest"
  definitions: # v2.4.0 or later
  $defs: # v3.0.0.rc or later
```

The OpenAPI specification define addtional property should have `x-` prefix so it is invalid schema and many tools (e.g. Swagger Editor, OpenAPI Generator) doesn't parse it.

```
The extensions properties are implemented as patterned fields that are always prefixed by "x-".
https://spec.openapis.org/oas/v3.1.0#specification-extensions
```


You can see this problem by thease commits.
[v2.5.2](https://github.com/ota42y/flask-openapi3/commit/463aaa0ecab7dccd2a662074d722dce8d633c5c1)
```
E           AssertionError: assert {'properties', 'required', 'title', 'type'} == {'properties', 'required', 'title', 'definitions', 'type'}
E             Extra items in the right set:
E             'definitions'
E             Full diff:
E             - {'properties', 'required', 'title', 'definitions', 'type'}
E             ?                                     ---------------
E             + {'properties', 'required', 'title', 'type'}
```

[v3.0.0.rc1](https://github.com/ota42y/flask-openapi3/commit/58831498700151d98fc23e1940de516a4e7dbef4)
```
E           AssertionError: assert {'type', 'properties', 'title', 'required'} == {'$defs', 'properties', 'type', 'title', 'required'}
E             Extra items in the right set:
E             '$defs'
E             Full diff:
E             - {'$defs', 'properties', 'type', 'title', 'required'}
E             ?   ^^ --                 --------
E             + {'type', 'properties', 'title', 'required'}
E             ?   ^^^
```


This problem caused by `extra = "allow"` option in the Schema class (from v2.5.0).
https://github.com/luolingchun/flask-openapi3/commit/f26f1c9e29fa17e072300d29bf1b7d3a7d4e691e#diff-2bada372333ea28442a21644e743c1e9d0998ad884df54eeaf12ce872544bfdaR53-R57

https://github.com/luolingchun/flask-openapi3/commit/f26f1c9e29fa17e072300d29bf1b7d3a7d4e691e#diff-a3335c7849ec34943fa7d6eb26c9f28d9d994e2142a50c7ce0387bae01d17f49L74-L79

In old version, when we executed `model_json_schema` in pydantic, it returned with these elements (`definitions`, `$refs`) included, but since this option was not defined until v2.4.0, `__init__` method ignore thease.
https://github.com/luolingchun/flask-openapi3/blob/master/flask_openapi3/utils.py#L254-L259

This change ignore proreties without defined and `x-` prefix, `$ref`.

