### PR TITLE
bugfix for parameter object

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -132,7 +132,9 @@ def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**value)
+        data.update(**dict(
+            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
+        ))
         parameters.append(Parameter(**data))
 
     # Parse definitions

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -29,6 +29,13 @@ from .types import ParametersTuple
 from .types import ResponseDict
 from .types import ResponseStrKeyDict
 
+# name, in, description, required, schema set by code so it's not included
+ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT = set([
+    "deprecated",
+    "example",
+    "examples"
+])
+
 
 def get_operation(
         func: Callable, *,
@@ -179,7 +186,9 @@ def parse_path(path: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**value)
+        data.update(**dict(
+            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
+        ))
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -206,7 +215,9 @@ def parse_query(query: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**value)
+        data.update(**dict(
+            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
+        ))
         parameters.append(Parameter(**data))
 
     # Parse definitions

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -29,13 +29,6 @@ from .types import ParametersTuple
 from .types import ResponseDict
 from .types import ResponseStrKeyDict
 
-# name, in, description, required, schema set by code so it's not included
-ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT = set([
-    "deprecated",
-    "example",
-    "examples"
-])
-
 
 def get_operation(
         func: Callable, *,
@@ -132,9 +125,11 @@ def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**dict(
-            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
-        ))
+        data.update({
+            "deprecated": value.get("deprecated"),
+            "example": value.get("example"),
+            "examples": value.get("examples"),
+        })
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -188,9 +183,11 @@ def parse_path(path: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**dict(
-            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
-        ))
+        data.update({
+            "deprecated": value.get("deprecated"),
+            "example": value.get("example"),
+            "examples": value.get("examples"),
+        })
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -217,9 +214,11 @@ def parse_query(query: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update(**dict(
-            filter(lambda item: item[0] in ALLOWED_FIELD_NAMES_FOR_PARAMETER_OBJECT, value.items())
-        ))
+        data.update({
+            "deprecated": value.get("deprecated"),
+            "example": value.get("example"),
+            "examples": value.get("examples"),
+        })
         parameters.append(Parameter(**data))
 
     # Parse definitions

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Optional
 
 from pydantic import BaseModel, Field
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from flask_openapi3 import OpenAPI
 
@@ -331,3 +331,97 @@ def test_body_with_complex_object(request):
         assert resp.status_code == 200
         assert set(["properties", "required", "title", "type"]) == set(
             resp.json['components']['schemas']['BaseRequestBody'].keys())
+
+
+class PathParam(BaseModel):
+    type_name: str = Field(..., description="id for path", deprecated=False, example="42", max_length=300)
+
+
+def test_path_parameter_object(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.post("/test")
+    def endpoint_test(path: PathParam):
+        return {}, 200
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["post"]["parameters"][0] == {
+            "deprecated": False,
+            "description": "id for path",
+            "example": "42",
+            "in": "path",
+            "name": "type_name",
+            "required": True,
+            "schema": {
+                "deprecated": False,
+                "description": "id for path",
+                'maxLength': 300,
+                "example": "42",
+                "title": "Type Name",
+                "type": "string",
+            },
+        }
+
+
+class QueryParam(BaseModel):
+    count: int = Field(..., description="count of param", deprecated=True, example=100, le=1000.0)
+
+
+def test_query_parameter_object(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.post("/test")
+    def endpoint_test(query: QueryParam):
+        return {}, 200
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["post"]["parameters"][0] == {
+            "deprecated": True,
+            "description": "count of param",
+            "example": 100,
+            "in": "query",
+            "name": "count",
+            "required": True,
+            "schema": {
+                "deprecated": True,
+                "description": "count of param",
+                'maximum': 1000.0,
+                "example": 100,
+                "title": "Count",
+                "type": "integer",
+            },
+        }
+
+
+class HeaderParam(BaseModel):
+    app_name: Optional[str] = Field(None, description="app name")
+
+
+def test_header_parameter_object(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.post("/test")
+    def endpoint_test(header: HeaderParam):
+        return {}, 200
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["post"]["parameters"][0] == {
+            "description": "app name",
+            "in": "header",
+            "name": "app_name",
+            "required": False,
+            "schema": {
+                "description": "app name",
+                "title": "App Name",
+                "type": "string",
+            },
+        }


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

The parameter object include all files in schema object by this code.
https://github.com/luolingchun/flask-openapi3/blob/master/flask_openapi3/utils.py#L181

But parameter object doesn't allow all fields, for example `title` `type` ( you can get these error for previous commit 24999e44ebfb7d1d06bbaad72bdcdc05bfbb0a34 )

````
E           AssertionError: assert {'deprecated'...: 'path', ...} == {'deprecated'...: 'path', ...}
E             Omitting 7 identical items, use -vv to show
E             Left contains 3 more items:
E             {'maxLength': 300, 'title': 'Type Name', 'type': 'string'}
E             Use -v to get more diff

E           AssertionError: assert {'deprecated'... 'query', ...} == {'deprecated'... 'query', ...}
E             Omitting 7 identical items, use -vv to show
E             Left contains 3 more items:
E             {'maximum': 1000.0, 'title': 'Count', 'type': 'integer'}
E             Use -v to get more diff
```

So we ignore unsupported fields.