### PR TITLE
bugfix for gneerics class

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -270,7 +270,8 @@ def parse_body(
     schema = get_model_schema(body)
     components_schemas = dict()
 
-    title = schema.get("title") or body.__name__
+    original_title = schema.get("title") or body.__name__
+    title = normalize_name(original_title)
     components_schemas[title] = Schema(**schema)
     if extra_body:
         content = {

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -10,9 +10,6 @@ from typing import get_type_hints, Dict, Type, Callable, List, Tuple, Optional, 
 from flask import make_response, current_app
 from flask.wrappers import Response as FlaskResponse
 from pydantic import BaseModel, ValidationError
-from pydantic.schema import normalize_name
-# GenerateJsonSchema class have this method in pydantic 2-x
-# use `from pydantic.json_schema import GenerateJsonSchema`
 
 from ._http import HTTP_STATUS, HTTPMethod
 from .models import Encoding
@@ -593,3 +590,7 @@ def convert_responses_key_to_string(responses: ResponseDict) -> ResponseStrKeyDi
         _responses[key] = value
 
     return _responses
+
+
+def normalize_name(name: str) -> str:
+    return re.sub(r'[^\w.\-]', '_', name)

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -228,7 +228,8 @@ def parse_form(
 
     assert properties, f"{form.__name__}'s properties cannot be empty."
 
-    title = schema.get("title") or form.__name__
+    original_title = schema.get("title") or form.__name__
+    title = normalize_name(original_title)
     components_schemas[title] = Schema(**schema)
     encoding = {}
     for k, v in properties.items():

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Generic, TypeVar, List
+
 from pydantic import BaseModel
+from pydantic.generics import GenericModel
 
 from flask_openapi3 import OpenAPI
 
@@ -331,3 +334,45 @@ def test_body_with_complex_object(request):
         assert resp.status_code == 200
         assert set(["properties", "required", "title", "type"]) == set(
             resp.json['components']['schemas']['BaseRequestBody'].keys())
+
+
+class Detail(BaseModel):
+    num: int
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class GenericResponse(GenericModel, Generic[T]):
+    detail: T
+
+
+class ListGenericResponse(GenericModel, Generic[T]):
+    items: List[GenericResponse[T]]
+
+
+def test_responses_with_generics(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.get("/test", responses={"201": ListGenericResponse[Detail]})
+    def endpoint_test():
+        return b'', 201
+
+    with test_app.test_client() as client:
+        resp = client.get("/openapi/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json["paths"]["/test"]["get"]["responses"]["201"] == {
+            "description": "Created",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ListGenericResponse_Detail_"}
+                },
+            },
+        }
+
+        schemas = resp.json["components"]["schemas"]
+        detail = schemas['ListGenericResponse_Detail_']
+        assert detail['title'] == 'ListGenericResponse[Detail]'
+        assert detail['properties']['items']['items']['$ref'] == '#/components/schemas/GenericResponse_Detail_'
+        assert schemas['GenericResponse_Detail_']['title'] == 'GenericResponse[Detail]'

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from typing import Generic, TypeVar, List
 
 from pydantic import BaseModel

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -307,10 +307,10 @@ def test_form_examples(request):
             }
         }
 
-    BaseRequest.Config = Config
+    BaseRequestGeneric[BaseRequest].Config = Config
 
     @test_app.post("/test")
-    def endpoint_test(form: BaseRequest):
+    def endpoint_test(form: BaseRequestGeneric[BaseRequest]):
         return form.json(), 200
 
     with test_app.test_client() as client:
@@ -319,13 +319,19 @@ def test_form_examples(request):
         assert resp.json["paths"]["/test"]["post"]["requestBody"] == {
             "content": {
                 "multipart/form-data": {
-                    "schema": {"$ref": "#/components/schemas/BaseRequest"},
+                    "schema": {"$ref": "#/components/schemas/BaseRequestGeneric_BaseRequest_"},
                     "examples": {
                         "Example 01": {"summary": "An example", "value": {"test_int": -1, "test_str": "negative"}}
                     }
                 }
             },
             "required": True
+        }
+        assert resp.json["components"]["schemas"]['BaseRequestGeneric_BaseRequest_'] == {
+            'properties': {'detail': {'$ref': '#/components/schemas/BaseRequest'}},
+            'required': ['detail'],
+            'title': 'BaseRequestGeneric[BaseRequest]',
+            'type': 'object',
         }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,5 +4,6 @@
 
 from flask_openapi3.utils import normalize_name
 
+
 def test_normalize_name():
     assert "List-Generic.Response_Detail_" == normalize_name("List-Generic.Response[Detail]")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2022/12/19 10:34
+
+from flask_openapi3.utils import normalize_name
+
+def test_normalize_name():
+    assert "List-Generic.Response_Detail_" == normalize_name("List-Generic.Response[Detail]")


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

When we use generics in responses, the schema name include `[]` but [OpenAPI 3 doesn't allow it](https://spec.openapis.org/oas/v3.1.0#components-object).

```
All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$.
```

The pydantic normalize all `$ref` but the schema name ( `components.schemas` ) set by this library so we shuld normalize name using pydantic's function.
