### PR TITLE
support for raw requests

### DIFF
--- a/docs/Usage/Request.md
+++ b/docs/Usage/Request.md
@@ -83,6 +83,26 @@ Receive flask **`request.headers`**.
 
 Receive flask **`request.cookies`**.
 
+### raw
+
+Receive flask **`request`** and no data validation.
+
+```python
+from flask_openapi3 import RawModel
+
+
+class BookRaw(RawModel):
+    mimetypes = ["text/csv", "application/json"]
+
+
+@app.post("/book")
+def get_book(raw: BookRaw):
+    # raw equals to flask.request
+    print(raw.data)
+    print(raw.mimetype)
+    return "ok"
+```
+
 ## Request model
 
 First, you need to define a [pydantic](https://github.com/pydantic/pydantic) model:

--- a/examples/raw_request_demo.py
+++ b/examples/raw_request_demo.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2023/9/12 17:19
+from flask_openapi3 import OpenAPI
+from flask_openapi3 import RawModel
+
+app = OpenAPI(__name__)
+
+
+class BookRaw(RawModel):
+    mimetype = "text/csv"
+
+
+@app.post("/book")
+def get_book(raw: BookRaw):
+    # raw equals to flask.request
+    print(raw.data)
+    print(raw.mimetype)
+    return "ok"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/raw_request_demo.py
+++ b/examples/raw_request_demo.py
@@ -8,7 +8,7 @@ app = OpenAPI(__name__)
 
 
 class BookRaw(RawModel):
-    mimetype = "text/csv"
+    mimetypes = ["text/csv", "application/json"]
 
 
 @app.post("/book")

--- a/flask_openapi3/__init__.py
+++ b/flask_openapi3/__init__.py
@@ -24,6 +24,7 @@ from .models import Operation
 from .models import Parameter
 from .models import ParameterInType
 from .models import PathItem
+from .models import RawModel
 from .models import Reference
 from .models import RequestBody
 from .models import Response

--- a/flask_openapi3/blueprint.py
+++ b/flask_openapi3/blueprint.py
@@ -178,7 +178,7 @@ class APIBlueprint(APIScaffold, Blueprint):
             tags = tags + self.abp_tags if tags else self.abp_tags
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)
             # Parse parameters
-            header, cookie, path, query, form, body = parse_parameters(
+            header, cookie, path, query, form, body, raw = parse_parameters(
                 func,
                 components_schemas=self.components_schemas,
                 operation=operation
@@ -191,8 +191,8 @@ class APIBlueprint(APIScaffold, Blueprint):
 
             # Parse method
             parse_method(uri, method, self.paths, operation)
-            return header, cookie, path, query, form, body
+            return header, cookie, path, query, form, body, raw
         else:
             # Parse parameters
-            header, cookie, path, query, form, body = parse_parameters(func, doc_ui=False)
-            return header, cookie, path, query, form, body
+            header, cookie, path, query, form, body, raw = parse_parameters(func, doc_ui=False)
+            return header, cookie, path, query, form, body, raw

--- a/flask_openapi3/models/__init__.py
+++ b/flask_openapi3/models/__init__.py
@@ -11,6 +11,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#table-o
 
 from typing import Optional, List, Dict
 
+from flask import Request
 from pydantic import BaseModel
 
 from .callback import Callback
@@ -81,6 +82,10 @@ class OAuthConfig(BaseModel):
     additionalQueryStringParams: Optional[Dict[str, str]] = None
     useBasicAuthenticationWithAccessCodeGrant: Optional[bool] = False
     usePkceWithAuthorizationCodeGrant: Optional[bool] = False
+
+
+class RawModel(Request):
+    media_type: str = "application/json"
 
 
 Encoding.model_rebuild()

--- a/flask_openapi3/models/__init__.py
+++ b/flask_openapi3/models/__init__.py
@@ -85,7 +85,7 @@ class OAuthConfig(BaseModel):
 
 
 class RawModel(Request):
-    mimetype: str = "application/json"
+    mimetypes: List[str] = ["application/json"]
 
 
 Encoding.model_rebuild()

--- a/flask_openapi3/models/__init__.py
+++ b/flask_openapi3/models/__init__.py
@@ -85,7 +85,7 @@ class OAuthConfig(BaseModel):
 
 
 class RawModel(Request):
-    media_type: str = "application/json"
+    mimetype: str = "application/json"
 
 
 Encoding.model_rebuild()

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -424,7 +424,7 @@ class OpenAPI(APIScaffold, Flask):
                 tags = []
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)
             # Parse parameters
-            header, cookie, path, query, form, body = parse_parameters(
+            header, cookie, path, query, form, body, raw = parse_parameters(
                 func,
                 components_schemas=self.components_schemas,
                 operation=operation
@@ -435,8 +435,8 @@ class OpenAPI(APIScaffold, Flask):
             uri = re.sub(r"<([^<:]+:)?", "{", rule).replace(">", "}")
             # Parse method
             parse_method(uri, method, self.paths, operation)
-            return header, cookie, path, query, form, body
+            return header, cookie, path, query, form, body, raw
         else:
             # Parse parameters
-            header, cookie, path, query, form, body = parse_parameters(func, doc_ui=False)
-            return header, cookie, path, query, form, body
+            header, cookie, path, query, form, body, raw = parse_parameters(func, doc_ui=False)
+            return header, cookie, path, query, form, body, raw

--- a/flask_openapi3/request.py
+++ b/flask_openapi3/request.py
@@ -97,6 +97,7 @@ def _validate_request(
         query: Optional[Type[BaseModel]] = None,
         form: Optional[Type[BaseModel]] = None,
         body: Optional[Type[BaseModel]] = None,
+        raw: Optional[Type[BaseModel]] = None,
         path_kwargs: Optional[Dict[Any, Any]] = None
 ) -> Dict:
     """
@@ -135,6 +136,8 @@ def _validate_request(
             _validate_form(form, func_kwargs)
         if body:
             _validate_body(body, func_kwargs)
+        if raw:
+            func_kwargs.update({"raw": request})
     except ValidationError as e:
         # Create a response with validation error details
         validation_error_callback = getattr(current_app, "validation_error_callback")

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -59,6 +59,7 @@ class APIScaffold:
             query,
             form,
             body,
+            raw,
             view_class=None,
             view_kwargs=None
     ):
@@ -73,6 +74,7 @@ class APIScaffold:
                     query=query,
                     form=form,
                     body=body,
+                    raw=raw,
                     path_kwargs=kwargs
                 )
 
@@ -98,6 +100,7 @@ class APIScaffold:
                     query=query,
                     form=form,
                     body=body,
+                    raw=raw,
                     path_kwargs=kwargs
                 )
 
@@ -156,7 +159,7 @@ class APIScaffold:
         """
 
         def decorator(func) -> Callable:
-            header, cookie, path, query, form, body = \
+            header, cookie, path, query, form, body, raw = \
                 self._collect_openapi_info(
                     rule,
                     func,
@@ -174,7 +177,7 @@ class APIScaffold:
                     method=HTTPMethod.GET
                 )
 
-            view_func = self.create_view_func(func, header, cookie, path, query, form, body)
+            view_func = self.create_view_func(func, header, cookie, path, query, form, body, raw)
             options.update({"methods": [HTTPMethod.GET]})
             self._add_url_rule(rule, view_func=view_func, **options)
 
@@ -219,7 +222,7 @@ class APIScaffold:
         """
 
         def decorator(func) -> Callable:
-            header, cookie, path, query, form, body = \
+            header, cookie, path, query, form, body, raw = \
                 self._collect_openapi_info(
                     rule,
                     func,
@@ -237,7 +240,7 @@ class APIScaffold:
                     method=HTTPMethod.POST
                 )
 
-            view_func = self.create_view_func(func, header, cookie, path, query, form, body)
+            view_func = self.create_view_func(func, header, cookie, path, query, form, body, raw)
             options.update({"methods": [HTTPMethod.POST]})
             self._add_url_rule(rule, view_func=view_func, **options)
 
@@ -282,7 +285,7 @@ class APIScaffold:
         """
 
         def decorator(func) -> Callable:
-            header, cookie, path, query, form, body = \
+            header, cookie, path, query, form, body, raw = \
                 self._collect_openapi_info(
                     rule,
                     func,
@@ -300,7 +303,7 @@ class APIScaffold:
                     method=HTTPMethod.PUT
                 )
 
-            view_func = self.create_view_func(func, header, cookie, path, query, form, body)
+            view_func = self.create_view_func(func, header, cookie, path, query, form, body, raw)
             options.update({"methods": [HTTPMethod.PUT]})
             self._add_url_rule(rule, view_func=view_func, **options)
 
@@ -345,7 +348,7 @@ class APIScaffold:
         """
 
         def decorator(func) -> Callable:
-            header, cookie, path, query, form, body = \
+            header, cookie, path, query, form, body, raw = \
                 self._collect_openapi_info(
                     rule,
                     func,
@@ -363,7 +366,7 @@ class APIScaffold:
                     method=HTTPMethod.DELETE
                 )
 
-            view_func = self.create_view_func(func, header, cookie, path, query, form, body)
+            view_func = self.create_view_func(func, header, cookie, path, query, form, body, raw)
             options.update({"methods": [HTTPMethod.DELETE]})
             self._add_url_rule(rule, view_func=view_func, **options)
 
@@ -408,7 +411,7 @@ class APIScaffold:
         """
 
         def decorator(func) -> Callable:
-            header, cookie, path, query, form, body = \
+            header, cookie, path, query, form, body, raw = \
                 self._collect_openapi_info(
                     rule,
                     func,
@@ -426,7 +429,7 @@ class APIScaffold:
                     method=HTTPMethod.PATCH
                 )
 
-            view_func = self.create_view_func(func, header, cookie, path, query, form, body)
+            view_func = self.create_view_func(func, header, cookie, path, query, form, body, raw)
             options.update({"methods": [HTTPMethod.PATCH]})
             self._add_url_rule(rule, view_func=view_func, **options)
 

--- a/flask_openapi3/types.py
+++ b/flask_openapi3/types.py
@@ -6,6 +6,7 @@ from typing import Dict, Union, Type, Any, Tuple, Optional
 
 from pydantic import BaseModel
 
+from .models import RawModel
 from .models import SecurityScheme
 
 _ResponseDictValue = Union[Type[BaseModel], Dict[Any, Any], None]
@@ -23,5 +24,5 @@ ParametersTuple = Tuple[
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],
-    Optional[Type[BaseModel]]
+    Optional[Type[RawModel]]
 ]

--- a/flask_openapi3/types.py
+++ b/flask_openapi3/types.py
@@ -22,5 +22,6 @@ ParametersTuple = Tuple[
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],
+    Optional[Type[BaseModel]],
     Optional[Type[BaseModel]]
 ]

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -486,11 +486,16 @@ def parse_parameters(
         operation.requestBody = request_body
 
     if raw:
-        _content = {
-            raw.mimetype: MediaType(
-                schema=Schema(type=DataType.STRING)
-            )
-        }
+        _content = {}
+        for mimetype in raw.mimetypes:
+            if mimetype.startswith("application/json"):
+                _content[mimetype] = MediaType(
+                    schema=Schema(type=DataType.OBJECT)
+                )
+            else:
+                _content[mimetype] = MediaType(
+                    schema=Schema(type=DataType.STRING)
+                )
         request_body = RequestBody(content=_content)
         operation.requestBody = request_body
 

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -21,6 +21,7 @@ from .models import Operation
 from .models import Parameter
 from .models import ParameterInType
 from .models import PathItem
+from .models import RawModel
 from .models import RequestBody
 from .models import Response
 from .models import Schema
@@ -412,16 +413,16 @@ def parse_parameters(
 
     """
     # Get the type hints from the function
-    annotations: Dict[str, Type[BaseModel]] = get_type_hints(func)
+    annotations = get_type_hints(func)
 
     # Get the types for header, cookie, path, query, form, and body parameters
-    header = annotations.get("header")
-    cookie = annotations.get("cookie")
-    path = annotations.get("path")
-    query = annotations.get("query")
-    form = annotations.get("form")
-    body = annotations.get("body")
-    raw = annotations.get("raw")
+    header: Optional[Type[BaseModel]] = annotations.get("header")
+    cookie: Optional[Type[BaseModel]] = annotations.get("cookie")
+    path: Optional[Type[BaseModel]] = annotations.get("path")
+    query: Optional[Type[BaseModel]] = annotations.get("query")
+    form: Optional[Type[BaseModel]] = annotations.get("form")
+    body: Optional[Type[BaseModel]] = annotations.get("body")
+    raw: Optional[Type[RawModel]] = annotations.get("raw")
 
     # If doc_ui is False, return the types without further processing
     if doc_ui is False:

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -25,6 +25,7 @@ from .models import RequestBody
 from .models import Response
 from .models import Schema
 from .models import Tag
+from .models.data_type import DataType
 from .types import ParametersTuple
 from .types import ResponseDict
 from .types import ResponseStrKeyDict
@@ -420,10 +421,11 @@ def parse_parameters(
     query = annotations.get("query")
     form = annotations.get("form")
     body = annotations.get("body")
+    raw = annotations.get("raw")
 
     # If doc_ui is False, return the types without further processing
     if doc_ui is False:
-        return header, cookie, path, query, form, body
+        return header, cookie, path, query, form, body, raw
 
     parameters = []
 
@@ -482,10 +484,19 @@ def parse_parameters(
             request_body.content["application/json"].encoding = openapi_extra.get("encoding")
         operation.requestBody = request_body
 
+    if raw:
+        _content = {
+            raw.mimetype: MediaType(
+                schema=Schema(type=DataType.STRING)
+            )
+        }
+        request_body = RequestBody(content=_content)
+        operation.requestBody = request_body
+
     # Set the parsed parameters in the operation object
     operation.parameters = parameters if parameters else None
 
-    return header, cookie, path, query, form, body
+    return header, cookie, path, query, form, body, raw
 
 
 def parse_method(uri: str, method: str, paths: dict, operation: Operation) -> None:

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -195,7 +195,7 @@ class APIView:
         for rule, (cls, methods) in self.views.items():
             for method in methods:
                 func = getattr(cls, method.lower())
-                header, cookie, path, query, form, body = parse_parameters(func, doc_ui=False)
+                header, cookie, path, query, form, body, raw = parse_parameters(func, doc_ui=False)
                 view_func = app.create_view_func(
                     func,
                     header,
@@ -204,6 +204,7 @@ class APIView:
                     query,
                     form,
                     body,
+                    raw,
                     view_class=cls,
                     view_kwargs=view_kwargs
                 )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pytest
 from pydantic import BaseModel, Field
 
-from flask_openapi3 import OpenAPI, FileStorage
+from flask_openapi3 import OpenAPI, FileStorage, RawModel
 
 app = OpenAPI(__name__)
 app.config["TESTING"] = True
@@ -85,6 +85,18 @@ def api_cookie(cookie: BookCookie):
     return {"code": 0, "message": "ok"}
 
 
+class BookRaw(RawModel):
+    mimetypes = ["text/csv", "application/json"]
+
+
+@app.post("/raw")
+def api_raw(raw: BookRaw):
+    # raw equals to flask.request
+    assert raw.data == b"raw"
+    assert raw.mimetype == "text/plain"
+    return "ok"
+
+
 def test_query(client):
     r = client.get("/query")
     print(r.json)
@@ -120,3 +132,8 @@ def test_header(client):
     print(resp.json)
     assert resp.status_code == 200
     assert resp.json == headers
+
+
+def test_raw(client):
+    resp = client.post("/raw", data="raw", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 200


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `flake8 flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.


Regarding the idea of supporting raw requests, there is no data validation and support for OpenAPI UI.

```python
from flask_openapi3 import OpenAPI
from flask_openapi3 import RawModel

app = OpenAPI(__name__)


class BookRaw(RawModel):
    mimetypes = ["text/csv", "application/json"]


@app.post("/book")
def get_book(raw: BookRaw):
    # raw equals to flask.request
    print(raw.data)
    print(raw.mimetype)
    return "ok"


if __name__ == "__main__":
    app.run(debug=True)
```