### PR TITLE
[#125] Enable to mark the RequestBody as Optional.

### DIFF
--- a/docs/Usage/Model_Config.md
+++ b/docs/Usage/Model_Config.md
@@ -76,6 +76,21 @@ Effect in swagger:
 
 ![](../assets/Snipaste_2023-06-02_11-06-59.png)
 
+
+
+You can use `reqiured` in `openapi_extra` to mark the RequestBody as Optional.
+
+```python
+class PingBody(BaseModel):
+        ping: Optional[str] = Field("ok", description="String to return, 'ok' when null.")
+
+        model_config = dict(
+            openapi_extra = {
+                "required": False
+            }
+        )
+```
+
 ### responses
 
 ```python

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -480,6 +480,7 @@ def parse_parameters(
         openapi_extra = model_config.get("openapi_extra")
         if openapi_extra:
             request_body.description = openapi_extra.get("description")
+            request_body.required = openapi_extra.get("required", True)
             request_body.content["application/json"].example = openapi_extra.get("example")
             request_body.content["application/json"].examples = openapi_extra.get("examples")
             request_body.content["application/json"].encoding = openapi_extra.get("encoding")


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `flake8 flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.


fix #125 