### PR TITLE
Fix mssing Pydantic Calculated Fields

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -12,6 +12,7 @@ from typing import get_type_hints, Dict, Type, Callable, List, Tuple, Optional, 
 from flask import make_response, current_app
 from flask.wrappers import Response as FlaskResponse
 from pydantic import BaseModel, ValidationError
+from pydantic.json_schema import JsonSchemaMode
 
 from .models import Encoding
 from .models import MediaType
@@ -116,7 +117,7 @@ def get_operation_id_for_path(*, name: str, path: str, method: str) -> str:
     return operation_id
 
 
-def get_model_schema(model: Type[BaseModel]) -> dict:
+def get_model_schema(model: Type[BaseModel], mode: JsonSchemaMode = 'validation') -> dict:
     """Converts a Pydantic model to an OpenAPI schema."""
 
     assert inspect.isclass(model) and issubclass(model, BaseModel), \
@@ -125,7 +126,7 @@ def get_model_schema(model: Type[BaseModel]) -> dict:
     model_config = model.model_config
     by_alias = bool(model_config.get("by_alias", True))
 
-    return model.model_json_schema(by_alias=by_alias, ref_template=OPENAPI3_REF_TEMPLATE)
+    return model.model_json_schema(by_alias=by_alias, ref_template=OPENAPI3_REF_TEMPLATE, mode=mode)
 
 
 def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
@@ -327,7 +328,7 @@ def get_responses(
         else:
             # OpenAPI 3 support ^[a-zA-Z0-9\.\-_]+$ so we should normalize __name__
             name = normalize_name(response.__name__)
-            schema = get_model_schema(response)
+            schema = get_model_schema(response, mode='serialization')
             _responses[key] = Response(
                 description=HTTP_STATUS.get(key, ""),
                 content={

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -117,7 +117,7 @@ def get_operation_id_for_path(*, name: str, path: str, method: str) -> str:
     return operation_id
 
 
-def get_model_schema(model: Type[BaseModel], mode: JsonSchemaMode = 'validation') -> dict:
+def get_model_schema(model: Type[BaseModel], mode: JsonSchemaMode = "validation") -> dict:
     """Converts a Pydantic model to an OpenAPI schema."""
 
     assert inspect.isclass(model) and issubclass(model, BaseModel), \
@@ -328,7 +328,7 @@ def get_responses(
         else:
             # OpenAPI 3 support ^[a-zA-Z0-9\.\-_]+$ so we should normalize __name__
             name = normalize_name(response.__name__)
-            schema = get_model_schema(response, mode='serialization')
+            schema = get_model_schema(response, mode="serialization")
             _responses[key] = Response(
                 description=HTTP_STATUS.get(key, ""),
                 content={
@@ -593,4 +593,4 @@ def convert_responses_key_to_string(responses: ResponseDict) -> ResponseStrKeyDi
 
 
 def normalize_name(name: str) -> str:
-    return re.sub(r'[^\w.\-]', '_', name)
+    return re.sub(r"[^\w.\-]", "_", name)

--- a/tests/test_pydantic_calculated_fields.py
+++ b/tests/test_pydantic_calculated_fields.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2024/1/28 16:38
+from functools import cached_property
+
+import pytest
+from pydantic import BaseModel, Field, computed_field
+
+from flask_openapi3 import OpenAPI
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+class User(BaseModel):
+    firstName: str = Field(title="First Name")
+    lastName: str
+
+    @computed_field(title="Display Name")
+    @cached_property
+    def display_name(self) -> str:
+        return f"{self.firstName} {self.lastName}"
+
+
+@app.get("/user", responses={200: User})
+def get_book():
+    return "ok"
+
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    import pprint
+    pprint.pprint(resp.json)
+    assert resp.json["components"]["schemas"]["User"]["properties"].get("display_name") is not None


### PR DESCRIPTION
Fixed issue with pydantic computed fields not appearing in openapi.json.

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.



fix #139 