### PR TITLE
Add the `swagger_config` parameter to configure the swagger ui

### DIFF
--- a/docs/Usage/Specification.md
+++ b/docs/Usage/Specification.md
@@ -269,6 +269,26 @@ More information to see [Configuration](https://github.com/swagger-api/swagger-u
 app = OpenAPI(__name__, info=info, doc_expansion='full')
 ```
 
+!!! Deprecated-Warning warning
+
+    `doc_expansion` have been merged into the `swagger_config`, and `doc_expansion` will be deprecated in the future.
+
+## swagger_config
+
+Swagger supports many configuration items. 
+For more information on Swagger Configuration,
+please refer to [Swagger Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md).
+
+```python
+app = OpenAPI(
+    __name__, 
+    swagger_config={
+        "doc_expansion": "none", 
+        "validatorUrl": "https://www.b.com"
+    }
+)
+```
+
 ## Interactive documentation
 
 **Flask OpenAPI3** provides support for the following Interactive documentation:

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -84,7 +84,7 @@ class OpenAPI(APIScaffold, Flask):
                           See https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/oauth2.md.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             doc_ui: Enable OpenAPI document UI (Swagger UI and Redoc). Defaults to True.
-            doc_expansion: Default expansion setting for operations and tags ("list", "full", or "none").
+            doc_expansion(deprecated): Default expansion setting for operations and tags ("list", "full", or "none").
                            See https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md.
             doc_prefix: URL prefix used for OpenAPI document and UI. Defaults to "/openapi"
             api_doc_url: URL for accessing the OpenAPI specification document in JSON format.

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -60,6 +60,7 @@ class OpenAPI(APIScaffold, Flask):
             swagger_url: str = "/swagger",
             redoc_url: str = "/redoc",
             rapidoc_url: str = "/rapidoc",
+            swagger_config: Optional[Dict[str, Any]] = None,
             ui_templates: Optional[Dict[str, str]] = None,
             servers: Optional[List[Server]] = None,
             external_docs: Optional[ExternalDocumentation] = None,
@@ -91,6 +92,8 @@ class OpenAPI(APIScaffold, Flask):
             swagger_url: URL for accessing the Swagger UI documentation. Defaults to "/swagger".
             redoc_url: URL for accessing the Redoc UI documentation. Defaults to "/redoc".
             rapidoc_url: URL for accessing the RapiDoc UI documentation. Defaults to "/rapidoc".
+            swagger_config: Swagger UI Configuration, More information:
+                            https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md.
             ui_templates: Custom UI templates to override or add UI documents.
             servers: An array of Server objects providing connectivity information to a target server.
             external_docs: External documentation for the API.
@@ -137,7 +140,13 @@ class OpenAPI(APIScaffold, Flask):
 
         # Set OAuth configuration and documentation expansion
         self.oauth_config = oauth_config
+        if doc_expansion != "list":
+            import warnings
+            warnings.filterwarnings("once")
+            warnings.warn("The `doc_expansion` parameter is deprecated; use `swagger_config` instead.",
+                          DeprecationWarning)
         self.doc_expansion = doc_expansion
+        self.swagger_config = swagger_config
 
         # Set UI templates for customization
         self.ui_templates = ui_templates or dict()
@@ -210,6 +219,7 @@ class OpenAPI(APIScaffold, Flask):
                     api_doc_url=self.api_doc_url.lstrip("/"),
                     # The following parameters are only for swagger ui
                     doc_expansion=self.doc_expansion,
+                    swagger_config=self.swagger_config,
                     oauth_config=self.oauth_config.model_dump() if self.oauth_config else None
                 )
             )

--- a/flask_openapi3/templates/__init__.py
+++ b/flask_openapi3/templates/__init__.py
@@ -142,10 +142,12 @@ swagger_html_string = """
 <script src="static/js/swagger-ui-bundle.js"></script>
 <script src="static/js/swagger-ui-standalone-preset.js"></script>
 <script>
+    const swagger_config = JSON.parse(`{{ swagger_config|tojson }}`);
     url = new URL("{{api_doc_url}}", window.location.href).href;
     window.onload = function () {
         // Begin Swagger UI call region
         window.ui = SwaggerUIBundle({
+        ...{
             url: url,
             dom_id: "#swagger-ui",
             deepLinking: true,
@@ -160,6 +162,8 @@ swagger_html_string = """
             docExpansion: "{{ doc_expansion }}",
             showExtensions: true,
             showCommonExtensions: true
+        },
+        ...swagger_config
         })
         // End Swagger UI call region
         const oauthConfig = JSON.parse(`{{ oauth_config|tojson }}`);

--- a/tests/test_swagger_config.py
+++ b/tests/test_swagger_config.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2024/3/10 14:48
+import pytest
+
+from flask_openapi3 import OpenAPI
+
+app = OpenAPI(__name__, swagger_config={"validatorUrl": "https://www.b.com"})
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json == app.api_doc
+
+
+def test_swagger(client):
+    resp = client.get("/openapi/swagger")
+    assert resp.status_code == 200
+    assert "https://www.b.com" in resp.text


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

fix: #145 
