### PR TITLE
Wrong types of exclusiveMinimum & exclusiveMaximum fields in Schema class

### DIFF
--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -20,9 +20,9 @@ class Schema(BaseModel):
     title: Optional[str] = None
     multipleOf: Optional[float] = Field(default=None, gt=0.0)
     maximum: Optional[float] = None
-    exclusiveMaximum: Optional[bool] = None
+    exclusiveMaximum: Optional[float] = None
     minimum: Optional[float] = None
-    exclusiveMinimum: Optional[bool] = None
+    exclusiveMinimum: Optional[float] = None
     maxLength: Optional[int] = Field(default=None, ge=0)
     minLength: Optional[int] = Field(default=None, ge=0)
     pattern: Optional[str] = None

--- a/tests/test_number_constraints.py
+++ b/tests/test_number_constraints.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2024/4/19 20:53
+
+import pytest
+from pydantic import BaseModel, Field
+
+from flask_openapi3 import OpenAPI
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+
+class MyModel(BaseModel):
+    num_1: int = Field(..., ge=1, le=10)
+    num_2: int = Field(..., gt=1, lt=10)
+
+
+@app.post('/book')
+def create_book(body: MyModel):
+    return body.dict()
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+    return client
+
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json == app.api_doc
+
+    model_props = resp.json['components']['schemas']['MyModel']['properties']
+    num_1_props = model_props['num_1']
+    num_2_props = model_props['num_2']
+
+    assert num_1_props['minimum'] == 1
+    assert num_1_props['maximum'] == 10
+    assert num_2_props['exclusiveMinimum'] == 1
+    assert num_2_props['exclusiveMaximum'] == 10


### PR DESCRIPTION
This fixes #150 
In `Schema` class `exclusiveMinimum` and `exclusiveMaximum` fields should be of type `float` instead of `bool`.
If you try to use the Pydantic `Field()` with the 'gt' or 'lt' constraint, the app crashes.

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `flake8 flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.
