### PR TITLE
Fix missing `Field.default` when it's value is `None` in openapi spec

### DIFF
--- a/flask_openapi3/blueprint.py
+++ b/flask_openapi3/blueprint.py
@@ -158,7 +158,8 @@ class APIBlueprint(APIScaffold, Blueprint):
             )
 
             # Set external docs
-            operation.externalDocs = external_docs
+            if external_docs:
+                operation.externalDocs = external_docs
 
             # Unique string used to identify the operation.
             operation.operationId = operation_id or self.operation_id_callback(
@@ -166,13 +167,17 @@ class APIBlueprint(APIScaffold, Blueprint):
             )
 
             # Only set `deprecated` if True, otherwise leave it as None
-            operation.deprecated = deprecated
+            if deprecated is not None:
+                operation.deprecated = deprecated
 
             # Add security
-            operation.security = (security or []) + self.abp_security or None
+            _security = (security or []) + self.abp_security or None
+            if _security:
+                operation.security = _security
 
             # Add servers
-            operation.servers = servers
+            if servers:
+                operation.servers = servers
 
             # Store tags
             tags = (tags or []) + self.abp_tags

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -242,6 +242,9 @@ class OpenAPI(APIScaffold, Flask):
 
         # Convert spec to JSON
         self.spec_json = json.loads(spec.model_dump_json(by_alias=True, exclude_none=True, warnings=False))
+        # fix to include `default=None` in fields
+        components_only = json.loads(spec.model_dump_json(by_alias=True, exclude_unset=True, warnings=False))["components"]
+        self.spec_json["components"] = components_only
 
         # Update with OpenAPI extensions
         self.spec_json.update(**self.openapi_extensions)

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2021/4/30 14:25
-import json
 import os
 import re
 import sys
@@ -241,9 +240,9 @@ class OpenAPI(APIScaffold, Flask):
         spec.components = self.components
 
         # Convert spec to JSON
-        self.spec_json = json.loads(spec.model_dump_json(by_alias=True, exclude_none=True, warnings=False))
+        self.spec_json = spec.model_dump(mode="json", by_alias=True, exclude_none=True, warnings=False, exclude={"components"})
         # fix to include `default=None` in fields
-        components_only = json.loads(spec.model_dump_json(by_alias=True, exclude_unset=True, warnings=False))["components"]
+        components_only = spec.model_dump(mode="json", by_alias=True, exclude_unset=True, warnings=False, include={"components"})["components"]
         self.spec_json["components"] = components_only
 
         # Update with OpenAPI extensions

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -527,8 +527,9 @@ def parse_parameters(
         request_body = RequestBody(content=_content)
         operation.requestBody = request_body
 
-    # Set the parsed parameters in the operation object
-    operation.parameters = parameters if parameters else None
+    if parameters:
+        # Set the parsed parameters in the operation object
+        operation.parameters = parameters
 
     return header, cookie, path, query, form, body, raw
 

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -73,19 +73,25 @@ def get_operation(
     doc = inspect.getdoc(func) or ""
     doc = doc.strip()
     lines = doc.split("\n")
-    doc_summary = lines[0] or None
+    doc_summary = lines[0]
 
     # Determine the summary and description based on provided arguments or docstring
     if summary is None:
-        doc_description = lines[0] if len(lines) == 0 else "</br>".join(lines[1:]) or None
+        doc_description = lines[0] if len(lines) == 0 else "</br>".join(lines[1:])
     else:
-        doc_description = "</br>".join(lines) or None
+        doc_description = "</br>".join(lines)
+
+    summary = summary or doc_summary
+    description = description or doc_description
 
     # Create the operation dictionary with summary and description
-    operation_dict = dict(
-        summary=summary or doc_summary,
-        description=description or doc_description
-    )
+    operation_dict = {"deprecated": False}
+
+    if summary:
+        operation_dict["summary"] = summary  # type: ignore
+
+    if description:
+        operation_dict["description"] = description  # type: ignore
 
     # Add any additional openapi_extensions to the operation dictionary
     operation_dict.update(openapi_extensions or {})
@@ -136,16 +142,18 @@ def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
         data = {
             "name": name,
             "in": ParameterInType.HEADER,
-            "description": value.get("description"),
             "required": name in schema.get("required", []),
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update({
-            "deprecated": value.get("deprecated"),
-            "example": value.get("example"),
-            "examples": value.get("examples"),
-        })
+        if "description" in value.keys():
+            data["description"] = value.get("description")
+        if "deprecated" in value.keys():
+            data["deprecated"] = value.get("deprecated")
+        if "example" in value.keys():
+            data["example"] = value.get("example")
+        if "examples" in value.keys():
+            data["examples"] = value.get("examples")
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -167,16 +175,18 @@ def parse_cookie(cookie: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
         data = {
             "name": name,
             "in": ParameterInType.COOKIE,
-            "description": value.get("description"),
             "required": name in schema.get("required", []),
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update({
-            "deprecated": value.get("deprecated"),
-            "example": value.get("example"),
-            "examples": value.get("examples"),
-        })
+        if "description" in value.keys():
+            data["description"] = value.get("description")
+        if "deprecated" in value.keys():
+            data["deprecated"] = value.get("deprecated")
+        if "example" in value.keys():
+            data["example"] = value.get("example")
+        if "examples" in value.keys():
+            data["examples"] = value.get("examples")
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -198,16 +208,18 @@ def parse_path(path: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
         data = {
             "name": name,
             "in": ParameterInType.PATH,
-            "description": value.get("description"),
             "required": True,
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update({
-            "deprecated": value.get("deprecated"),
-            "example": value.get("example"),
-            "examples": value.get("examples"),
-        })
+        if "description" in value.keys():
+            data["description"] = value.get("description")
+        if "deprecated" in value.keys():
+            data["deprecated"] = value.get("deprecated")
+        if "example" in value.keys():
+            data["example"] = value.get("example")
+        if "examples" in value.keys():
+            data["examples"] = value.get("examples")
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -229,16 +241,18 @@ def parse_query(query: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
         data = {
             "name": name,
             "in": ParameterInType.QUERY,
-            "description": value.get("description"),
             "required": name in schema.get("required", []),
             "schema": Schema(**value)
         }
         # Parse extra values
-        data.update({
-            "deprecated": value.get("deprecated"),
-            "example": value.get("example"),
-            "examples": value.get("examples"),
-        })
+        if "description" in value.keys():
+            data["description"] = value.get("description")
+        if "deprecated" in value.keys():
+            data["deprecated"] = value.get("deprecated")
+        if "example" in value.keys():
+            data["example"] = value.get("example")
+        if "examples" in value.keys():
+            data["examples"] = value.get("examples")
         parameters.append(Parameter(**data))
 
     # Parse definitions
@@ -269,9 +283,10 @@ def parse_form(
     content = {
         "multipart/form-data": MediaType(
             schema=Schema(**{"$ref": f"{OPENAPI3_REF_PREFIX}/{title}"}),
-            encoding=encoding or None
         )
     }
+    if encoding:
+        content["multipart/form-data"].encoding = encoding
 
     # Parse definitions
     definitions = schema.get("$defs", {})
@@ -332,18 +347,24 @@ def get_responses(
                     )})
 
             model_config: DefaultDict[str, Any] = response.model_config  # type: ignore
-            openapi_extra = model_config.get("openapi_extra")
+            openapi_extra = model_config.get("openapi_extra", {})
             if openapi_extra:
+                openapi_extra_keys = openapi_extra.keys()
                 # Add additional information from model_config to the response
-                _responses[key].description = openapi_extra.get("description")
-                _responses[key].headers = openapi_extra.get("headers")
-                _responses[key].links = openapi_extra.get("links")
+                if "description" in openapi_extra_keys:
+                    _responses[key].description = openapi_extra.get("description")
+                if "headers" in openapi_extra_keys:
+                    _responses[key].headers = openapi_extra.get("headers")
+                if "links" in openapi_extra_keys:
+                    _responses[key].links = openapi_extra.get("links")
                 _content = _responses[key].content
-                if _content is not None:
-                    _content["application/json"].example = openapi_extra.get("example")
-                    _content["application/json"].examples = openapi_extra.get("examples")
-                    _content["application/json"].encoding = openapi_extra.get("encoding")
-                    _content.update(openapi_extra.get("content", {}))
+                if "example" in openapi_extra_keys:
+                    _content["application/json"].example = openapi_extra.get("example")  # type: ignore
+                if "examples" in openapi_extra_keys:
+                    _content["application/json"].examples = openapi_extra.get("examples")  # type: ignore
+                if "encoding" in openapi_extra_keys:
+                    _content["application/json"].encoding = openapi_extra.get("encoding")  # type: ignore
+                _content.update(openapi_extra.get("content", {}))  # type: ignore
 
             _schemas[name] = Schema(**schema)
             definitions = schema.get("$defs")
@@ -382,8 +403,8 @@ def parse_and_store_tags(
             old_tags.append(tag)
 
     # Set the tags attribute of the operation object to a list of unique tag names from new_tags
-    # If the resulting list is empty, set it to None
-    operation.tags = list(set([tag.name for tag in new_tags])) or None
+    # If the resulting list is empty, set it to ["default"]
+    operation.tags = list(set([tag.name for tag in new_tags])) or ["default"]
 
 
 def parse_parameters(
@@ -415,7 +436,7 @@ def parse_parameters(
 
     # If operation is None, initialize it as an Operation object
     if operation is None:
-        operation = Operation()
+        operation = Operation(deprecated=False)
 
     # Get the type hints from the function
     annotations = get_type_hints(func)
@@ -458,29 +479,38 @@ def parse_parameters(
     if form:
         _content, _components_schemas = parse_form(form)
         components_schemas.update(**_components_schemas)
-        request_body = RequestBody(content=_content)
+        request_body = RequestBody(content=_content, required=True)
         model_config: DefaultDict[str, Any] = form.model_config  # type: ignore
-        openapi_extra = model_config.get("openapi_extra")
+        openapi_extra = model_config.get("openapi_extra", {})
         if openapi_extra:
-            request_body.description = openapi_extra.get("description")
-            request_body.content["multipart/form-data"].example = openapi_extra.get("example")
-            request_body.content["multipart/form-data"].examples = openapi_extra.get("examples")
-            if openapi_extra.get("encoding"):
+            openapi_extra_keys = openapi_extra.keys()
+            if "description" in openapi_extra_keys:
+                request_body.description = openapi_extra.get("description")
+            if "example" in openapi_extra_keys:
+                request_body.content["multipart/form-data"].example = openapi_extra.get("example")
+            if "examples" in openapi_extra_keys:
+                request_body.content["multipart/form-data"].examples = openapi_extra.get("examples")
+            if "encoding" in openapi_extra_keys:
                 request_body.content["multipart/form-data"].encoding = openapi_extra.get("encoding")
         operation.requestBody = request_body
 
     if body:
         _content, _components_schemas = parse_body(body)
         components_schemas.update(**_components_schemas)
-        request_body = RequestBody(content=_content)
+        request_body = RequestBody(content=_content, required=True)
         model_config: DefaultDict[str, Any] = body.model_config  # type: ignore
-        openapi_extra = model_config.get("openapi_extra")
+        openapi_extra = model_config.get("openapi_extra", {})
         if openapi_extra:
-            request_body.description = openapi_extra.get("description")
+            openapi_extra_keys = openapi_extra.keys()
+            if "description" in openapi_extra_keys:
+                request_body.description = openapi_extra.get("description")
             request_body.required = openapi_extra.get("required", True)
-            request_body.content["application/json"].example = openapi_extra.get("example")
-            request_body.content["application/json"].examples = openapi_extra.get("examples")
-            request_body.content["application/json"].encoding = openapi_extra.get("encoding")
+            if "example" in openapi_extra_keys:
+                request_body.content["application/json"].example = openapi_extra.get("example")
+            if "examples" in openapi_extra_keys:
+                request_body.content["application/json"].examples = openapi_extra.get("examples")
+            if "encoding" in openapi_extra_keys:
+                request_body.content["application/json"].encoding = openapi_extra.get("encoding")
         operation.requestBody = request_body
 
     if raw:

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -85,7 +85,7 @@ def get_operation(
     description = description or doc_description
 
     # Create the operation dictionary with summary and description
-    operation_dict = {"deprecated": False}
+    operation_dict = {}
 
     if summary:
         operation_dict["summary"] = summary  # type: ignore
@@ -436,7 +436,7 @@ def parse_parameters(
 
     # If operation is None, initialize it as an Operation object
     if operation is None:
-        operation = Operation(deprecated=False)
+        operation = Operation()
 
     # Get the type hints from the function
     annotations = get_type_hints(func)

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -152,19 +152,25 @@ class APIView:
             )
 
             # Set external docs
-            operation.externalDocs = external_docs
+            if external_docs:
+                operation.externalDocs = external_docs
 
             # Unique string used to identify the operation.
-            operation.operationId = operation_id
+            if operation_id:
+                operation.operationId = operation_id
 
             # Only set `deprecated` if True, otherwise leave it as None
-            operation.deprecated = deprecated
+            if deprecated is not None:
+                operation.deprecated = deprecated
 
             # Add security
-            operation.security = security + self.view_security or None
+            _security = (security or []) + self.view_security or None
+            if _security:
+                operation.security = _security
 
             # Add servers
-            operation.servers = servers
+            if servers:
+                operation.servers = servers
 
             # Store tags
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar, List
+from typing import Generic, TypeVar, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -495,3 +495,25 @@ def test_header_parameter_object(request):
             "required": False,
             "schema": {"description": "app name", "example": "aaa", "title": "App Name", "type": "string"}
         }
+
+
+
+class Model(BaseModel):
+    one: Optional[int] = Field(default=None)
+    two: Optional[int] = Field(default=2)
+
+def test_default_none(request):
+    test_app = OpenAPI(request.node.name)
+    test_app.config["TESTING"] = True
+
+    @test_app.post("/test")
+    def endpoint_test(body:Model):
+        print([])  # pragma: no cover
+
+
+    works = Model.model_json_schema()["properties"]
+    assert works["one"]["default"] is None
+    assert works["two"]["default"] ==2
+    breaks = test_app.api_doc["components"]["schemas"]["Model"]["properties"]
+    assert breaks["two"]["default"] == 2
+    assert breaks["one"]["default"] is None

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -517,3 +517,16 @@ def test_default_none(request):
     breaks = test_app.api_doc["components"]["schemas"]["Model"]["properties"]
     assert breaks["two"]["default"] == 2
     assert breaks["one"]["default"] is None
+
+
+def test_parameters_none(request):
+    """Parameters key shouldn't exist."""
+    test_app = OpenAPI(request.node.name)
+
+    @test_app.post("/test")
+    def endpoint_test():
+        print([])  # pragma: no cover
+
+    data = test_app.api_doc["paths"]["/test"]["post"]
+
+    assert "parameters" not in data

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -530,3 +530,16 @@ def test_parameters_none(request):
     data = test_app.api_doc["paths"]["/test"]["post"]
 
     assert "parameters" not in data
+
+
+def test_deprecated_none(request):
+    """Parameters key shouldn't exist."""
+    test_app = OpenAPI(request.node.name)
+
+    @test_app.post("/test")
+    def endpoint_test():
+        print([])  # pragma: no cover
+
+    data = test_app.api_doc["paths"]["/test"]["post"]
+
+    assert "deprecated" not in data

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -485,7 +485,7 @@ def test_header_parameter_object(request):
             "in": "header",
             "name": "app_name",
             "required": False,
-            "schema": {"description": "app name", "title": "App Name", "type": "string"}
+            "schema": {"description": "app name", "title": "App Name", "type": "string", "default": None}
         }
         assert resp.json["paths"]["/test"]["post"]["parameters"][1] == {
             "description": "app name",
@@ -493,27 +493,27 @@ def test_header_parameter_object(request):
             "example": "aaa",
             "name": "app_name",
             "required": False,
-            "schema": {"description": "app name", "example": "aaa", "title": "App Name", "type": "string"}
+            "schema": {"description": "app name", "example": "aaa", "title": "App Name", "type": "string",
+                       "default": None}
         }
-
 
 
 class Model(BaseModel):
     one: Optional[int] = Field(default=None)
     two: Optional[int] = Field(default=2)
 
+
 def test_default_none(request):
     test_app = OpenAPI(request.node.name)
     test_app.config["TESTING"] = True
 
     @test_app.post("/test")
-    def endpoint_test(body:Model):
+    def endpoint_test(body: Model):
         print([])  # pragma: no cover
-
 
     works = Model.model_json_schema()["properties"]
     assert works["one"]["default"] is None
-    assert works["two"]["default"] ==2
+    assert works["two"]["default"] == 2
     breaks = test_app.api_doc["components"]["schemas"]["Model"]["properties"]
     assert breaks["two"]["default"] == 2
     assert breaks["one"]["default"] is None


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.
