### PR TITLE
Allow subclasses to modify the default error response registered.

### DIFF
--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -245,8 +245,11 @@ class OpenAPI(APIScaffold, Flask):
 
         # Update with OpenAPI extensions
         self.spec_json.update(**self.openapi_extensions)
+        self._register_default_error_responses()
+        return self.spec_json
 
-        # Handle validation error response
+    def _register_default_error_responses(self):
+        """Register error response on all endpoints."""
         for rule, path_item in self.spec_json["paths"].items():
             for http_method, operation in path_item.items():
                 if operation.get("parameters") is None and operation.get("requestBody") is None:
@@ -266,8 +269,6 @@ class OpenAPI(APIScaffold, Flask):
                         }
                     }
                 }
-
-        return self.spec_json
 
     def register_api(self, api: APIBlueprint) -> None:
         """


### PR DESCRIPTION
I have a different error response and I want to modify the registered default errors. This seems the simplest way.

----------

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.
