### PR TITLE
ServerVariable.enum should be optional

### DIFF
--- a/flask_openapi3/models/server_variable.py
+++ b/flask_openapi3/models/server_variable.py
@@ -3,7 +3,7 @@
 # @Time    : 2023/7/4 9:57
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ServerVariable(BaseModel):
@@ -11,7 +11,7 @@ class ServerVariable(BaseModel):
     https://spec.openapis.org/oas/v3.1.0#server-variable-object
     """
 
-    enum: List[str]
+    enum: Optional[List[str]] = Field(None, min_length=1)
     default: str
     description: Optional[str] = None
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2024/11/10 12:17
+from pydantic import ValidationError
+
+from flask_openapi3 import Server, ServerVariable
+
+
+def test_server_variable():
+    Server(
+        url="http://127.0.0.1:5000",
+        variables=None
+    )
+    try:
+        variables = {"one": ServerVariable(default="one", enum=[])}
+        Server(
+            url="http://127.0.0.1:5000",
+            variables=variables
+        )
+        error = 0
+    except ValidationError:
+        error = 1
+    assert error == 1
+    try:
+        variables = {"one": ServerVariable(default="one")}
+        Server(
+            url="http://127.0.0.1:5000",
+            variables=variables
+        )
+        error = 0
+    except ValidationError:
+        error = 1
+    assert error == 0
+    try:
+        variables = {"one": ServerVariable(default="one", enum=["one", "two"])}
+        Server(
+            url="http://127.0.0.1:5000",
+            variables=variables
+        )
+        error = 0
+    except ValidationError:
+        error = 1
+    assert error == 0


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.

fix: #188 