### PR TITLE
Add PrefixItems to Schema Model for use with Tuple types

### DIFF
--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -39,6 +39,7 @@ class Schema(BaseModel):
     anyOf: Optional[List[Union[Reference, "Schema"]]] = None
     schema_not: Optional[Union[Reference, "Schema"]] = Field(default=None, alias="not")
     items: Optional[Union[Reference, "Schema"]] = None
+    prefixItems: Optional[List[Union[Reference, "Schema"]]] = None
     properties: Optional[Dict[str, Union[Reference, "Schema"]]] = None
     additionalProperties: Optional[Union[bool, Reference, "Schema"]] = None
     description: Optional[str] = None


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed. (Was unable to run this locally, but I didnt touch any of the docs, so assuming it has to do with my local setup)
