### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The key features are:
 
 ## Requirements
 
-Python 3.8+
+Python 3.9+
 
 flask-openapi3 is dependent on the following libraries:
 

--- a/docs/Usage/Model_Config.md
+++ b/docs/Usage/Model_Config.md
@@ -130,7 +130,7 @@ Sometimes you may not want to use aliases (such as in the responses model). In t
 ```python
 class MessageResponse(BaseModel):
     message: str = Field(..., description="The message")
-    metadata: Dict[str, str] = Field(alias="metadata_")
+    metadata: dict[str, str] = Field(alias="metadata_")
 
     model_config = dict(
         by_alias=False

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -32,7 +32,7 @@
 
 ## 依赖
 
-Python 3.8+
+Python 3.9+
 
 flask-openapi3 依赖以下库：
 

--- a/examples/openapi_extra.py
+++ b/examples/openapi_extra.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/6/1 15:04
-from typing import List
-
 from pydantic import BaseModel
 
 from flask_openapi3 import OpenAPI, FileStorage
@@ -12,7 +10,7 @@ app = OpenAPI(__name__)
 
 class UploadFilesForm(BaseModel):
     file: FileStorage
-    str_list: List[str]
+    str_list: list[str]
 
     model_config = dict(
         openapi_extra={

--- a/examples/pydantic_custom_root_types.py
+++ b/examples/pydantic_custom_root_types.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2022/2/27 15:26
-from typing import List, Dict, Any
+from typing import Any
 
 from pydantic import BaseModel, RootModel
 
@@ -16,15 +16,15 @@ class Sellout(BaseModel):
 
 
 class SelloutList(RootModel):
-    root: List[Sellout]
+    root: list[Sellout]
 
 
 class SelloutDict(RootModel):
-    root: Dict[str, Sellout]
+    root: dict[str, Sellout]
 
 
 class SelloutDict2(RootModel):
-    root: Dict[Any, Any]
+    root: dict[Any, Any]
 
 
 class SelloutDict3(BaseModel):

--- a/examples/rest_demo.py
+++ b/examples/rest_demo.py
@@ -2,7 +2,7 @@
 # @Author  : llc
 # @Time    : 2021/4/28 11:24
 from http import HTTPStatus
-from typing import Optional, List
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -66,7 +66,7 @@ class BookPath(BaseModel):
 
 class BookQuery(BaseModel):
     age: Optional[int] = Field(None, description='Age')
-    s_list: List[str] = Field(None, alias='s_list[]', description='some array')
+    s_list: list[str] = Field(None, alias='s_list[]', description='some array')
 
 
 class BookBody(BaseModel):

--- a/examples/upload_file_demo.py
+++ b/examples/upload_file_demo.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2021/5/11 14:03
-
-from typing import List
-
 from pydantic import BaseModel, Field
 
 from flask_openapi3 import OpenAPI, FileStorage
@@ -17,9 +14,9 @@ class UploadFileForm(BaseModel):
 
 
 class UploadFilesForm(BaseModel):
-    files: List[FileStorage]
-    str_list: List[str]
-    int_list: List[int]
+    files: list[FileStorage]
+    str_list: list[str]
+    int_list: list[int]
 
 
 @app.post('/upload/file')

--- a/flask_openapi3/blueprint.py
+++ b/flask_openapi3/blueprint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2022/4/1 16:54
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, Any, Callable
 
 from flask import Blueprint
 
@@ -28,8 +28,8 @@ class APIBlueprint(APIScaffold, Blueprint):
             name: str,
             import_name: str,
             *,
-            abp_tags: Optional[List[Tag]] = None,
-            abp_security: Optional[List[Dict[str, List[str]]]] = None,
+            abp_tags: Optional[list[Tag]] = None,
+            abp_security: Optional[list[dict[str, list[str]]]] = None,
             abp_responses: Optional[ResponseDict] = None,
             doc_ui: bool = True,
             operation_id_callback: Callable = get_operation_id_for_path,
@@ -54,10 +54,10 @@ class APIBlueprint(APIScaffold, Blueprint):
         super(APIBlueprint, self).__init__(name, import_name, **kwargs)
 
         # Initialize instance variables
-        self.paths: Dict = dict()
-        self.components_schemas: Dict = dict()
-        self.tags: List[Tag] = []
-        self.tag_names: List[str] = []
+        self.paths: dict = dict()
+        self.components_schemas: dict = dict()
+        self.tags: list[Tag] = []
+        self.tag_names: list[str] = []
 
         # Set values from arguments or default values
         self.abp_tags = abp_tags or []
@@ -111,16 +111,16 @@ class APIBlueprint(APIScaffold, Blueprint):
             rule: str,
             func: Callable,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:

--- a/flask_openapi3/models/__init__.py
+++ b/flask_openapi3/models/__init__.py
@@ -9,7 +9,7 @@ The type orders are according to the contents of the specification:
 https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#table-of-contents
 """
 
-from typing import Optional, List, Dict, Union
+from typing import Optional, Union
 
 from flask import Request
 from pydantic import BaseModel
@@ -57,13 +57,13 @@ class APISpec(BaseModel):
     """https://spec.openapis.org/oas/v3.1.0#openapi-object"""
     openapi: str
     info: Info
-    servers: Optional[List[Server]] = None
+    servers: Optional[list[Server]] = None
     paths: Paths
     components: Optional[Components] = None
-    security: Optional[List[SecurityRequirement]] = None
-    tags: Optional[List[Tag]] = None
+    security: Optional[list[SecurityRequirement]] = None
+    tags: Optional[list[Tag]] = None
     externalDocs: Optional[ExternalDocumentation] = None
-    webhooks: Optional[Dict[str, Union[PathItem, Reference]]] = None
+    webhooks: Optional[dict[str, Union[PathItem, Reference]]] = None
 
     model_config = {
         "extra": "allow"
@@ -80,13 +80,13 @@ class OAuthConfig(BaseModel):
     appName: Optional[str] = None
     scopeSeparator: Optional[str] = None
     scopes: Optional[str] = None
-    additionalQueryStringParams: Optional[Dict[str, str]] = None
+    additionalQueryStringParams: Optional[dict[str, str]] = None
     useBasicAuthenticationWithAccessCodeGrant: Optional[bool] = False
     usePkceWithAuthorizationCodeGrant: Optional[bool] = False
 
 
 class RawModel(Request):
-    mimetypes: List[str] = ["application/json"]
+    mimetypes: list[str] = ["application/json"]
 
 
 Encoding.model_rebuild()

--- a/flask_openapi3/models/callback.py
+++ b/flask_openapi3/models/callback.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:35
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .path_item import PathItem
@@ -15,4 +15,4 @@ that describes a set of requests that may be initiated by the API provider and t
 The key value used to identify the path item object is an expression, evaluated at runtime,
 that identifies a URL to use for the callback operation.
 """
-Callback = Dict[str, PathItem]
+Callback = dict[str, PathItem]

--- a/flask_openapi3/models/components.py
+++ b/flask_openapi3/models/components.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:36
-from typing import Dict, Optional, Union, Any
+from typing import Optional, Union, Any
 
 from pydantic import BaseModel, Field
 
@@ -23,16 +23,16 @@ class Components(BaseModel):
     https://spec.openapis.org/oas/v3.1.0#components-object
     """
 
-    schemas: Optional[Dict[str, Union[Reference, Schema]]] = Field(None)
-    responses: Optional[Dict[str, Union[Response, Reference]]] = None
-    parameters: Optional[Dict[str, Union[Parameter, Reference]]] = None
-    examples: Optional[Dict[str, Union[Example, Reference]]] = None
-    requestBodies: Optional[Dict[str, Union[RequestBody, Reference]]] = None
-    headers: Optional[Dict[str, Union[Header, Reference]]] = None
-    securitySchemes: Optional[Dict[str, Union[SecurityScheme, Dict[str, Any]]]] = None
-    links: Optional[Dict[str, Union[Link, Reference]]] = None
-    callbacks: Optional[Dict[str, Union[Callback, Reference]]] = None
-    pathItems: Optional[Dict[str, Union[PathItem, Reference]]] = None
+    schemas: Optional[dict[str, Union[Reference, Schema]]] = Field(None)
+    responses: Optional[dict[str, Union[Response, Reference]]] = None
+    parameters: Optional[dict[str, Union[Parameter, Reference]]] = None
+    examples: Optional[dict[str, Union[Example, Reference]]] = None
+    requestBodies: Optional[dict[str, Union[RequestBody, Reference]]] = None
+    headers: Optional[dict[str, Union[Header, Reference]]] = None
+    securitySchemes: Optional[dict[str, Union[SecurityScheme, dict[str, Any]]]] = None
+    links: Optional[dict[str, Union[Link, Reference]]] = None
+    callbacks: Optional[dict[str, Union[Callback, Reference]]] = None
+    pathItems: Optional[dict[str, Union[PathItem, Reference]]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/discriminator.py
+++ b/flask_openapi3/models/discriminator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:41
-from typing import Dict, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -12,7 +12,7 @@ class Discriminator(BaseModel):
     """
 
     propertyName: str
-    mapping: Optional[Dict[str, str]] = None
+    mapping: Optional[dict[str, str]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/encoding.py
+++ b/flask_openapi3/models/encoding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:41
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ class Encoding(BaseModel):
     """
 
     contentType: Optional[str] = None
-    headers: Optional[Dict[str, Union[Header, Reference]]] = None
+    headers: Optional[dict[str, Union[Header, Reference]]] = None
     style: Optional[str] = None
     explode: Optional[bool] = None
     allowReserved: bool = False

--- a/flask_openapi3/models/link.py
+++ b/flask_openapi3/models/link.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:45
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class Link(BaseModel):
 
     operationRef: Optional[str] = None
     operationId: Optional[str] = None
-    parameters: Optional[Dict[str, Any]] = None
+    parameters: Optional[dict[str, Any]] = None
     requestBody: Optional[Any] = None
     description: Optional[str] = None
     server: Optional[Server] = None

--- a/flask_openapi3/models/media_type.py
+++ b/flask_openapi3/models/media_type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:46
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -18,8 +18,8 @@ class MediaType(BaseModel):
 
     media_type_schema: Optional[Union[Reference, Schema]] = Field(default=None, alias="schema")
     example: Optional[Any] = None
-    examples: Optional[Dict[str, Union[Example, Reference]]] = None
-    encoding: Optional[Dict[str, Encoding]] = None
+    examples: Optional[dict[str, Union[Example, Reference]]] = None
+    encoding: Optional[dict[str, Encoding]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/oauth_flow.py
+++ b/flask_openapi3/models/oauth_flow.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:47
-from typing import Dict, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -14,7 +14,7 @@ class OAuthFlow(BaseModel):
     authorizationUrl: Optional[str] = None
     tokenUrl: Optional[str] = None
     refreshUrl: Optional[str] = None
-    scopes: Dict[str, str]
+    scopes: dict[str, str]
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/operation.py
+++ b/flask_openapi3/models/operation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:48
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -20,19 +20,19 @@ class Operation(BaseModel):
     https://spec.openapis.org/oas/v3.1.0#operation-object
     """
 
-    tags: Optional[List[str]] = None
+    tags: Optional[list[str]] = None
     summary: Optional[str] = None
     description: Optional[str] = None
     externalDocs: Optional[ExternalDocumentation] = None
     operationId: Optional[str] = None
-    parameters: Optional[List[Parameter]] = None
+    parameters: Optional[list[Parameter]] = None
     requestBody: Optional[Union[RequestBody, Reference]] = None
-    responses: Optional[Dict[str, Response]] = None
-    callbacks: Optional[Dict[str, Callback]] = None
+    responses: Optional[dict[str, Response]] = None
+    callbacks: Optional[dict[str, Callback]] = None
 
     deprecated: Optional[bool] = False
-    security: Optional[List[SecurityRequirement]] = None
-    servers: Optional[List[Server]] = None
+    security: Optional[list[SecurityRequirement]] = None
+    servers: Optional[list[Server]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/parameter.py
+++ b/flask_openapi3/models/parameter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:49
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -28,8 +28,8 @@ class Parameter(BaseModel):
     allowReserved: Optional[bool] = None
     param_schema: Optional[Union[Reference, Schema]] = Field(default=None, alias="schema")
     example: Optional[Any] = None
-    examples: Optional[Dict[str, Union[Example, Reference]]] = None
-    content: Optional[Dict[str, MediaType]] = None
+    examples: Optional[dict[str, Union[Example, Reference]]] = None
+    content: Optional[dict[str, MediaType]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/path_item.py
+++ b/flask_openapi3/models/path_item.py
@@ -2,7 +2,7 @@
 # @Author  : llc
 # @Time    : 2023/7/4 9:50
 import typing
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -29,8 +29,8 @@ class PathItem(BaseModel):
     head: Optional["Operation"] = None
     patch: Optional["Operation"] = None
     trace: Optional["Operation"] = None
-    servers: Optional[List[Server]] = None
-    parameters: Optional[List[Union[Parameter, Reference]]] = None
+    servers: Optional[list[Server]] = None
+    parameters: Optional[list[Union[Parameter, Reference]]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/paths.py
+++ b/flask_openapi3/models/paths.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:52
-from typing import Dict
-
 from .path_item import PathItem
 
 """
 https://spec.openapis.org/oas/v3.1.0#paths-object
 """
-Paths = Dict[str, PathItem]
+Paths = dict[str, PathItem]

--- a/flask_openapi3/models/request_body.py
+++ b/flask_openapi3/models/request_body.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:53
-from typing import Dict, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -14,7 +14,7 @@ class RequestBody(BaseModel):
     """
 
     description: Optional[str] = None
-    content: Dict[str, MediaType]
+    content: dict[str, MediaType]
     required: Optional[bool] = True
 
     model_config = {

--- a/flask_openapi3/models/response.py
+++ b/flask_openapi3/models/response.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:54
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -17,9 +17,9 @@ class Response(BaseModel):
     """
 
     description: str
-    headers: Optional[Dict[str, Union[Header, Reference]]] = None
-    content: Optional[Dict[str, MediaType]] = None
-    links: Optional[Dict[str, Union[Link, Reference]]] = None
+    headers: Optional[dict[str, Union[Header, Reference]]] = None
+    content: Optional[dict[str, MediaType]] = None
+    links: Optional[dict[str, Union[Link, Reference]]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/responses.py
+++ b/flask_openapi3/models/responses.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:55
-from typing import Dict, Union
+from typing import Union
 
 from .reference import Reference
 from .response import Response
@@ -9,4 +9,4 @@ from .response import Response
 """
 https://spec.openapis.org/oas/v3.1.0#responses-object
 """
-Responses = Dict[str, Union[Response, Reference]]
+Responses = dict[str, Union[Response, Reference]]

--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:55
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -31,16 +31,16 @@ class Schema(BaseModel):
     uniqueItems: Optional[bool] = None
     maxProperties: Optional[int] = Field(default=None, ge=0)
     minProperties: Optional[int] = Field(default=None, ge=0)
-    required: Optional[List[str]] = Field(default=None)
-    enum: Union[None, List[Any]] = Field(default=None)
+    required: Optional[list[str]] = Field(default=None)
+    enum: Union[None, list[Any]] = Field(default=None)
     type: Optional[DataType] = Field(default=None)
-    allOf: Optional[List[Union[Reference, "Schema"]]] = None
-    oneOf: Optional[List[Union[Reference, "Schema"]]] = None
-    anyOf: Optional[List[Union[Reference, "Schema"]]] = None
+    allOf: Optional[list[Union[Reference, "Schema"]]] = None
+    oneOf: Optional[list[Union[Reference, "Schema"]]] = None
+    anyOf: Optional[list[Union[Reference, "Schema"]]] = None
     schema_not: Optional[Union[Reference, "Schema"]] = Field(default=None, alias="not")
     items: Optional[Union[Reference, "Schema"]] = None
-    prefixItems: Optional[List[Union[Reference, "Schema"]]] = None
-    properties: Optional[Dict[str, Union[Reference, "Schema"]]] = None
+    properties: Optional[dict[str, Union[Reference, "Schema"]]] = None
+    prefixItems: Optional[list[Union[Reference, "Schema"]]] = None
     additionalProperties: Optional[Union[bool, Reference, "Schema"]] = None
     description: Optional[str] = None
     schema_format: Optional[str] = Field(default=None, alias="format")

--- a/flask_openapi3/models/security_requirement.py
+++ b/flask_openapi3/models/security_requirement.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:56
-from typing import Dict, List
-
 """
 https://spec.openapis.org/oas/v3.1.0#security-requirement-object
 """
-SecurityRequirement = Dict[str, List[str]]
+SecurityRequirement = dict[str, list[str]]

--- a/flask_openapi3/models/server.py
+++ b/flask_openapi3/models/server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2021/4/28 11:26
-from typing import Dict, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class Server(BaseModel):
 
     url: str
     description: Optional[str] = None
-    variables: Optional[Dict[str, ServerVariable]] = None
+    variables: Optional[dict[str, ServerVariable]] = None
 
     model_config = {
         "extra": "allow"

--- a/flask_openapi3/models/server_variable.py
+++ b/flask_openapi3/models/server_variable.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:57
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -11,7 +11,7 @@ class ServerVariable(BaseModel):
     https://spec.openapis.org/oas/v3.1.0#server-variable-object
     """
 
-    enum: Optional[List[str]] = Field(None, min_length=1)
+    enum: Optional[list[str]] = Field(None, min_length=1)
     default: str
     description: Optional[str] = None
 

--- a/flask_openapi3/models/validation_error.py
+++ b/flask_openapi3/models/validation_error.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2021/5/10 14:51
-from typing import List, Dict, Any, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
 
 class ValidationErrorModel(BaseModel):
     # More information: https://docs.pydantic.dev/latest/usage/models/#error-handling
-    loc: Optional[List[str]] = Field(None, title="Location", description="the error's location as a list. ")
+    loc: Optional[list[str]] = Field(None, title="Location", description="the error's location as a list. ")
     msg: Optional[str] = Field(None, title="Message", description="a computer-readable identifier of the error type.")
     type_: Optional[str] = Field(None, title="Error Type", description="a human readable explanation of the error.")
-    ctx: Optional[Dict[str, Any]] = Field(
+    ctx: Optional[dict[str, Any]] = Field(
         None,
         title="Error context",
         description="an optional object which contains values required to render the error message."

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from importlib import import_module
-from typing import Optional, List, Dict, Union, Any, Type, Callable
+from typing import Optional, Union, Any, Type, Callable
 
 from flask import Flask, Blueprint, render_template_string
 from pydantic import BaseModel
@@ -53,10 +53,10 @@ class OpenAPI(APIScaffold, Flask):
             info: Optional[Info] = None,
             security_schemes: Optional[SecuritySchemesDict] = None,
             responses: Optional[ResponseDict] = None,
-            servers: Optional[List[Server]] = None,
+            servers: Optional[list[Server]] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id_callback: Callable = get_operation_id_for_path,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             validation_error_status: Union[str, int] = 422,
             validation_error_model: Type[BaseModel] = ValidationErrorModel,
             validation_error_callback: Callable = make_validation_error_response,
@@ -110,13 +110,13 @@ class OpenAPI(APIScaffold, Flask):
         self.responses = convert_responses_key_to_string(responses or {})
 
         # Initialize instance variables
-        self.paths: Dict = dict()
-        self.components_schemas: Dict = dict()
+        self.paths: dict = dict()
+        self.components_schemas: dict = dict()
         self.components = Components()
 
         # Initialize lists for tags and tag names
-        self.tags: List[Tag] = []
-        self.tag_names: List[str] = []
+        self.tags: list[Tag] = []
+        self.tag_names: list[str] = []
 
         # Set URL prefixes and endpoints
         self.doc_prefix = doc_prefix
@@ -145,7 +145,7 @@ class OpenAPI(APIScaffold, Flask):
         self.cli.add_command(openapi_command)  # type: ignore
 
         # Initialize specification JSON
-        self.spec_json: Dict = {}
+        self.spec_json: dict = {}
         self.spec = APISpec(
             openapi=self.openapi_version,
             info=self.info,
@@ -209,7 +209,7 @@ class OpenAPI(APIScaffold, Flask):
         self.register_blueprint(blueprint)
 
     @property
-    def api_doc(self) -> Dict:
+    def api_doc(self) -> dict:
         """
         Generate the OpenAPI specification JSON.
 
@@ -320,7 +320,7 @@ class OpenAPI(APIScaffold, Flask):
             self,
             api_view: APIView,
             url_prefix: Optional[str] = None,
-            view_kwargs: Optional[Dict[Any, Any]] = None
+            view_kwargs: Optional[dict[Any, Any]] = None
     ) -> None:
         """
         Register APIView
@@ -370,16 +370,16 @@ class OpenAPI(APIScaffold, Flask):
             rule: str,
             func: Callable,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:

--- a/flask_openapi3/request.py
+++ b/flask_openapi3/request.py
@@ -3,7 +3,7 @@
 # @Time    : 2022/4/1 16:54
 import json
 from json import JSONDecodeError
-from typing import Any, Type, Optional, Dict
+from typing import Any, Type, Optional
 
 from flask import request, current_app, abort
 from pydantic import ValidationError, BaseModel
@@ -154,8 +154,8 @@ def _validate_request(
         form: Optional[Type[BaseModel]] = None,
         body: Optional[Type[BaseModel]] = None,
         raw: Optional[Type[BaseModel]] = None,
-        path_kwargs: Optional[Dict[Any, Any]] = None
-) -> Dict:
+        path_kwargs: Optional[dict[Any, Any]] = None
+) -> dict:
     """
     Validate requests and responses.
 
@@ -169,14 +169,14 @@ def _validate_request(
         path_kwargs: Path parameters.
 
     Returns:
-        Dict: Request kwargs.
+        dict: Request kwargs.
 
     Raises:
         ValidationError: If validation fails.
     """
 
     # Dictionary to store func kwargs
-    func_kwargs: Dict = {}
+    func_kwargs: dict = {}
 
     try:
         # Validate header, cookie, path, and query parameters

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -3,7 +3,7 @@
 # @Time    : 2022/8/30 9:40
 import inspect
 from functools import wraps
-from typing import Callable, List, Optional, Dict, Any
+from typing import Callable, Optional, Any
 
 from flask.wrappers import Response as FlaskResponse
 
@@ -22,16 +22,16 @@ class APIScaffold:
             rule: str,
             func: Callable,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:
@@ -126,16 +126,16 @@ class APIScaffold:
             self,
             rule: str,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             **options: Any
     ) -> Callable:
@@ -189,16 +189,16 @@ class APIScaffold:
             self,
             rule: str,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             **options: Any
     ) -> Callable:
@@ -252,16 +252,16 @@ class APIScaffold:
             self,
             rule: str,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             **options: Any
     ) -> Callable:
@@ -315,16 +315,16 @@ class APIScaffold:
             self,
             rule: str,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             **options: Any
     ) -> Callable:
@@ -378,16 +378,16 @@ class APIScaffold:
             self,
             rule: str,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True,
             **options: Any
     ) -> Callable:

--- a/flask_openapi3/templates.py
+++ b/flask_openapi3/templates.py
@@ -97,7 +97,7 @@ a/x3gCx7M2rvrU8m3suK+3w+AcssZ50vnfwAAAABJRU5ErkJggg==
     <div style="color: white; grid-column: span 2; display: flex; flex-direction: column; grid-column-end: 5;">
         <p>Please install at least one optional UI:</p>
         <p style="font-family: Consolas; background-color: #404348; border-radius: 5px; padding: 5px; font-size: 12px">
-        $ pip install -U flask-openapi3[swagger, redoc, rapidoc, rapipdf, scalar, elements]
+        $ pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]
         </p>
         <p>More optional ui templates goto the document about
         <a href="https://luolingchun.github.io/flask-openapi3/latest/Usage/UI_Templates/" style="color: #0969da">

--- a/flask_openapi3/types.py
+++ b/flask_openapi3/types.py
@@ -2,22 +2,22 @@
 # @Author  : llc
 # @Time    : 2023/7/9 15:25
 from http import HTTPStatus
-from typing import Dict, Union, Type, Any, Tuple, Optional
+from typing import Union, Type, Any, Optional
 
 from pydantic import BaseModel
 
 from .models import RawModel
 from .models import SecurityScheme
 
-_ResponseDictValue = Union[Type[BaseModel], Dict[Any, Any], None]
+_ResponseDictValue = Union[Type[BaseModel], dict[Any, Any], None]
 
-ResponseDict = Dict[Union[str, int, HTTPStatus], _ResponseDictValue]
+ResponseDict = dict[Union[str, int, HTTPStatus], _ResponseDictValue]
 
-ResponseStrKeyDict = Dict[str, _ResponseDictValue]
+ResponseStrKeyDict = dict[str, _ResponseDictValue]
 
-SecuritySchemesDict = Dict[str, Union[SecurityScheme, Dict[str, Any]]]
+SecuritySchemesDict = dict[str, Union[SecurityScheme, dict[str, Any]]]
 
-ParametersTuple = Tuple[
+ParametersTuple = tuple[
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],
     Optional[Type[BaseModel]],

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -7,7 +7,7 @@ import re
 import sys
 from enum import Enum
 from http import HTTPStatus
-from typing import get_type_hints, Dict, Type, Callable, List, Tuple, Optional, Any, DefaultDict
+from typing import get_type_hints, Type, Callable, Optional, Any, DefaultDict
 
 from flask import make_response, current_app
 from flask.wrappers import Response as FlaskResponse
@@ -54,7 +54,7 @@ def get_operation(
         func: Callable, *,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        openapi_extensions: Optional[Dict[str, Any]] = None,
+        openapi_extensions: Optional[dict[str, Any]] = None,
 ) -> Operation:
     """
     Return an Operation object with the specified summary and description.
@@ -131,11 +131,11 @@ def get_model_schema(model: Type[BaseModel], mode: JsonSchemaMode = "validation"
     return model.model_json_schema(by_alias=by_alias, ref_template=OPENAPI3_REF_TEMPLATE, mode=mode)
 
 
-def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
+def parse_header(header: Type[BaseModel]) -> tuple[list[Parameter], dict]:
     """Parses a header model and returns a list of parameters and component schemas."""
     schema = get_model_schema(header)
     parameters = []
-    components_schemas: Dict = dict()
+    components_schemas: dict = dict()
     properties = schema.get("properties", {})
 
     for name, value in properties.items():
@@ -164,11 +164,11 @@ def parse_header(header: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
     return parameters, components_schemas
 
 
-def parse_cookie(cookie: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
+def parse_cookie(cookie: Type[BaseModel]) -> tuple[list[Parameter], dict]:
     """Parses a cookie model and returns a list of parameters and component schemas."""
     schema = get_model_schema(cookie)
     parameters = []
-    components_schemas: Dict = dict()
+    components_schemas: dict = dict()
     properties = schema.get("properties", {})
 
     for name, value in properties.items():
@@ -197,11 +197,11 @@ def parse_cookie(cookie: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
     return parameters, components_schemas
 
 
-def parse_path(path: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
+def parse_path(path: Type[BaseModel]) -> tuple[list[Parameter], dict]:
     """Parses a path model and returns a list of parameters and component schemas."""
     schema = get_model_schema(path)
     parameters = []
-    components_schemas: Dict = dict()
+    components_schemas: dict = dict()
     properties = schema.get("properties", {})
 
     for name, value in properties.items():
@@ -230,11 +230,11 @@ def parse_path(path: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
     return parameters, components_schemas
 
 
-def parse_query(query: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
+def parse_query(query: Type[BaseModel]) -> tuple[list[Parameter], dict]:
     """Parses a query model and returns a list of parameters and component schemas."""
     schema = get_model_schema(query)
     parameters = []
-    components_schemas: Dict = dict()
+    components_schemas: dict = dict()
     properties = schema.get("properties", {})
 
     for name, value in properties.items():
@@ -265,7 +265,7 @@ def parse_query(query: Type[BaseModel]) -> Tuple[List[Parameter], dict]:
 
 def parse_form(
         form: Type[BaseModel],
-) -> Tuple[Dict[str, MediaType], dict]:
+) -> tuple[dict[str, MediaType], dict]:
     """Parses a form model and returns a list of parameters and component schemas."""
     schema = get_model_schema(form)
     components_schemas = dict()
@@ -298,7 +298,7 @@ def parse_form(
 
 def parse_body(
         body: Type[BaseModel],
-) -> Tuple[Dict[str, MediaType], dict]:
+) -> tuple[dict[str, MediaType], dict]:
     """Parses a body model and returns a list of parameters and component schemas."""
     schema = get_model_schema(body)
     components_schemas = dict()
@@ -379,9 +379,9 @@ def get_responses(
 
 
 def parse_and_store_tags(
-        new_tags: List[Tag],
-        old_tags: List[Tag],
-        old_tag_names: List[str],
+        new_tags: list[Tag],
+        old_tags: list[Tag],
+        old_tag_names: list[str],
         operation: Operation
 ) -> None:
     """
@@ -411,7 +411,7 @@ def parse_and_store_tags(
 def parse_parameters(
         func: Callable,
         *,
-        components_schemas: Optional[Dict] = None,
+        components_schemas: Optional[dict] = None,
         operation: Optional[Operation] = None,
         doc_ui: bool = True,
 ) -> ParametersTuple:
@@ -426,7 +426,7 @@ def parse_parameters(
         doc_ui: Flag indicating whether to return types for documentation UI (default: True).
 
     Returns:
-        Tuple[Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel]]:
+        tuple[Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel]]:
         The types for header, cookie, path, query, form, and body parameters respectively.
 
     """

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -2,7 +2,7 @@
 # @Author  : llc
 # @Time    : 2022/10/14 16:09
 import typing
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, Any, Callable
 
 from .models import ExternalDocumentation
 from .models import Server
@@ -26,8 +26,8 @@ class APIView:
     def __init__(
             self,
             url_prefix: Optional[str] = None,
-            view_tags: Optional[List[Tag]] = None,
-            view_security: Optional[List[Dict[str, List[str]]]] = None,
+            view_tags: Optional[list[Tag]] = None,
+            view_security: Optional[list[dict[str, list[str]]]] = None,
             view_responses: Optional[ResponseDict] = None,
             doc_ui: bool = True,
             operation_id_callback: Callable = get_operation_id_for_path,
@@ -55,11 +55,11 @@ class APIView:
         self.doc_ui = doc_ui
         self.operation_id_callback: Callable = operation_id_callback
 
-        self.views: Dict = dict()
-        self.paths: Dict = dict()
-        self.components_schemas: Dict = dict()
-        self.tags: List[Tag] = []
-        self.tag_names: List[str] = []
+        self.views: dict = dict()
+        self.paths: dict = dict()
+        self.components_schemas: dict = dict()
+        self.tags: list[Tag] = []
+        self.tag_names: list[str] = []
 
     def route(self, rule: str):
         """Decorator for view class"""
@@ -102,16 +102,16 @@ class APIView:
     def doc(
             self,
             *,
-            tags: Optional[List[Tag]] = None,
+            tags: Optional[list[Tag]] = None,
             summary: Optional[str] = None,
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
-            security: Optional[List[Dict[str, List[Any]]]] = None,
-            servers: Optional[List[Server]] = None,
-            openapi_extensions: Optional[Dict[str, Any]] = None,
+            security: Optional[list[dict[str, list[Any]]]] = None,
+            servers: Optional[list[Server]] = None,
+            openapi_extensions: Optional[dict[str, Any]] = None,
             doc_ui: bool = True
     ) -> Callable:
         """
@@ -194,7 +194,7 @@ class APIView:
             self,
             app: "OpenAPI",
             url_prefix: Optional[str] = None,
-            view_kwargs: Optional[Dict[Any, Any]] = None
+            view_kwargs: Optional[dict[Any, Any]] = None
     ) -> None:
         """
         Register the API views with the given OpenAPI app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["Flask>=2.0", "pydantic>=2.4"]
 dynamic = ["version"]
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -2,7 +2,7 @@
 # @Author  : llc
 # @Time    : 2023/8/6 13:47
 from enum import Enum
-from typing import List, Union, Dict, Any
+from typing import Union, Any
 
 import pytest
 from pydantic import BaseModel
@@ -35,21 +35,21 @@ class FileType(int, Enum):
 
 class FormParameters(BaseModel):
     file: FileStorage
-    file_list: List[FileStorage]
+    file_list: list[FileStorage]
     file_type: FileType
     number: float
-    number_list: List[float]
+    number_list: list[float]
     boolean: bool
-    boolean_list: List[bool]
+    boolean_list: list[bool]
     digit: int
-    digit_list: List[int]
+    digit_list: list[int]
     string: str
-    string_list: List[str]
-    obj: Dict[Any, Any]
+    string_list: list[str]
+    obj: dict[Any, Any]
     parameter: MetadataParameter
-    parameter_dict: Dict[str, MetadataParameter]
-    parameter_list: List[MetadataParameter]
-    parameter_list_union: List[Union[bool, float, str, int, FileType, MetadataParameter]]
+    parameter_dict: dict[str, MetadataParameter]
+    parameter_list: list[MetadataParameter]
+    parameter_list_union: list[Union[bool, float, str, int, FileType, MetadataParameter]]
     parameter_union: Union[MetadataParameter, MetadataParameter2]
     union_all: Union[str, int, float, bool, FileType, MetadataParameter]
     none: None = None
@@ -57,7 +57,7 @@ class FormParameters(BaseModel):
 
 
 class FormParameter(BaseModel):
-    obj: Dict[Any, Any]
+    obj: dict[Any, Any]
 
     model_config = dict(
         openapi_extra={

--- a/tests/test_list_with_default_value.py
+++ b/tests/test_list_with_default_value.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2024/9/29 10:36
-from typing import List
-
 import pytest
 from pydantic import BaseModel
 
@@ -20,11 +18,11 @@ def client():
 
 
 class BookQuery(BaseModel):
-    age: List[int] = [1, 2]
+    age: list[int] = [1, 2]
 
 
 class BookForm(BaseModel):
-    age: List[float] = [3, 4]
+    age: list[float] = [3, 4]
 
 
 @app.get("/query")

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/6/30 10:12
-from typing import List, Dict
-
 import pytest
 from pydantic import BaseModel, Field
 
@@ -14,7 +12,7 @@ app.config["TESTING"] = True
 
 class UploadFilesForm(BaseModel):
     file: FileStorage
-    str_list: List[str]
+    str_list: list[str]
 
     model_config = dict(
         openapi_extra={
@@ -70,7 +68,7 @@ class BookBody(BaseModel):
 
 class MessageResponse(BaseModel):
     message: str = Field(..., description="The message")
-    metadata: Dict[str, str] = Field(alias="metadata_")
+    metadata: dict[str, str] = Field(alias="metadata_")
 
     model_config = dict(
         by_alias=False,

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar, List, Optional, Tuple, Literal
+from typing import Generic, TypeVar, Optional, Literal
 
 from pydantic import BaseModel, Field
 
@@ -363,7 +363,7 @@ class GenericResponse(BaseModel, Generic[T]):
 
 
 class ListGenericResponse(BaseModel, Generic[T]):
-    items: List[GenericResponse[T]]
+    items: list[GenericResponse[T]]
 
 
 def test_responses_with_generics(request):
@@ -546,7 +546,7 @@ def test_deprecated_none(request):
 
 
 class TupleModel(BaseModel):
-    my_tuple: Tuple[Literal["a", "b"], Literal["c", "d"]]
+    my_tuple: tuple[Literal["a", "b"], Literal["c", "d"]]
 
 
 def test_prefix_items(request):

--- a/tests/test_populate_by_name.py
+++ b/tests/test_populate_by_name.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2024/8/31 15:35
-from typing import Sequence, List, Tuple
+from typing import Sequence
 
 import pytest
 from pydantic import BaseModel, Field
@@ -38,7 +38,7 @@ def get_book(query: BookQuery):
 class QueryModel(BaseModel):
     aliased_field: str = Field(alias="aliasedField")
 
-    aliased_list_field: List[str] = Field(alias="aliasedListField")
+    aliased_list_field: list[str] = Field(alias="aliasedListField")
 
 
 @app.get("/query-alias-test")
@@ -59,7 +59,7 @@ def get_book_header(header: HeaderModel):
 
 
 class TupleModel(BaseModel):
-    values: Tuple[int, int]
+    values: tuple[int, int]
     sequence: Sequence[int] = Field(alias="Sequence")
 
     model_config = {"populate_by_name": True}

--- a/tests/test_pydantic_custom_root_types.py
+++ b/tests/test_pydantic_custom_root_types.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2022/2/27 16:53
-from typing import List, Dict, Any
+from typing import Any
 
 import pytest
 from pydantic import BaseModel, RootModel
@@ -18,15 +18,15 @@ class Sellout(BaseModel):
 
 
 class SelloutList(RootModel):
-    root: List[Sellout]
+    root: list[Sellout]
 
 
 class SelloutDict(RootModel):
-    root: Dict[str, Sellout]
+    root: dict[str, Sellout]
 
 
 class SelloutDict2(RootModel):
-    root: Dict[Any, Any]
+    root: dict[Any, Any]
 
 
 class SelloutDict3(BaseModel):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3,7 +3,7 @@
 # @Time    : 2022/9/2 15:35
 from enum import Enum
 from functools import wraps
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 from pydantic import BaseModel, Field
@@ -28,13 +28,13 @@ class TypeEnum(str, Enum):
 
 class BookForm(BaseModel):
     file: FileStorage
-    files: List[FileStorage]
+    files: list[FileStorage]
     string: str
-    string_list: List[str]
+    string_list: list[str]
 
 
 class BookQuery(BaseModel):
-    age: List[int]
+    age: list[int]
     book_type: Optional[TypeEnum] = None
 
 

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from http import HTTPStatus
-from typing import Optional, List
+from typing import Optional
 
 import pytest
 from flask import Response
@@ -73,15 +73,15 @@ class BaseResponse(BaseModel):
 
 
 class BookListResponseV1(BaseResponse):
-    data: List[BookBodyWithID] = Field(..., description="All the books")
+    data: list[BookBodyWithID] = Field(..., description="All the books")
 
 
 class BookListResponseV2(BaseModel):
-    books: List[BookBodyWithID] = Field(...)
+    books: list[BookBodyWithID] = Field(...)
 
 
 class BookListResponseV3(RootModel):
-    root: List[BookBodyWithID]
+    root: list[BookBodyWithID]
 
 
 class BookResponse(BaseModel):

--- a/tests/test_validation_error.py
+++ b/tests/test_validation_error.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/21 10:32
-from typing import List
-
 import pytest
 from flask import make_response, current_app
 from pydantic import BaseModel, Field, ValidationError
@@ -20,7 +18,7 @@ class GenericTracebackError(BaseModel):
 class ValidationErrorModel(BaseModel):
     code: str
     message: str
-    more_info: List[GenericTracebackError] = Field(..., json_schema_extra={"example": [GenericTracebackError(
+    more_info: list[GenericTracebackError] = Field(..., json_schema_extra={"example": [GenericTracebackError(
         location="GenericError.py",
         line=1,
         method="GenericError",


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.
