### PR TITLE
Support multiple media types under the same status code

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -180,6 +180,38 @@ if __name__ == '__main__':
     app.run(debug=True)
 ```
 
+## Multiple media types
+
+```python
+
+@app.get(
+    '/book/<int:bid>',
+    tags=[book_tag],
+    summary='new summary',
+    description='new description',
+    responses={
+        200: {
+            "description": "Multiple media types under the same status code",
+            "content": {
+                "application/json": BookResponse,
+                "application/xml": BookResponse,
+            }
+        },
+        201: {"content": {"text/csv": {"schema": {"type": "string"}}}}
+    },
+    security=security
+)
+def get_book(path: BookPath):
+    """Get a book
+    to get some book by id, like:
+    http://localhost:5000/book/3
+    """
+    if path.bid == 4:
+        return NotFoundResponse().dict(), 404
+    return {"code": 0, "message": "ok", "data": {"bid": path.bid, "age": 3, "author": 'no'}}
+
+```
+
 ## APIBlueprint
 
 ```python


### PR DESCRIPTION
Checklist

- [x] Run `pytest tests` and none is failing - `They failed because they were already failing`
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.


This PR is to be able to support multiple media types for the same status code of an endpoint

```python
# Endpoints
api = APIBlueprint(
    "default",
    __name__,
    doc_ui=True,
)

class Project(BaseModel):
    Version: str
    Environment: str


@api.get(
    "/",
    responses={
        HTTPStatus.OK: {
            "description": "Health check",
            "content": {
                # Content type
                "application/json": Project,
                "application/bson": Project,
            },
        },
    },
)
def get_home():
    """Check status.

    Gets health status of the api.
    """
    output = Project(Version="1.0.0", Environment="dev")
    return output
```