### PR TITLE
Support request body and multiple media types under the same status code

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -180,6 +180,38 @@ if __name__ == '__main__':
     app.run(debug=True)
 ```
 
+## Multiple media types
+
+```python
+
+@app.get(
+    '/book/<int:bid>',
+    tags=[book_tag],
+    summary='new summary',
+    description='new description',
+    responses={
+        200: {
+            "description": "Multiple media types under the same status code",
+            "content": {
+                "application/json": BookResponse,
+                "application/xml": BookResponse,
+            }
+        },
+        201: {"content": {"text/csv": {"schema": {"type": "string"}}}}
+    },
+    security=security
+)
+def get_book(path: BookPath):
+    """Get a book
+    to get some book by id, like:
+    http://localhost:5000/book/3
+    """
+    if path.bid == 4:
+        return NotFoundResponse().dict(), 404
+    return {"code": 0, "message": "ok", "data": {"bid": path.bid, "age": 3, "author": 'no'}}
+
+```
+
 ## APIBlueprint
 
 ```python

--- a/flask_openapi3/models/request_body.py
+++ b/flask_openapi3/models/request_body.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # @Author  : llc
 # @Time    : 2023/7/4 9:53
-from typing import Dict, Optional
+from typing import Dict, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -14,7 +14,7 @@ class RequestBody(BaseModel):
     """
 
     description: Optional[str] = None
-    content: Dict[str, MediaType]
+    content: Dict[str, Union[MediaType, Type[BaseModel]]]
     required: Optional[bool] = True
 
     model_config = {

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Optional, Dict, Any
 from flask.wrappers import Response as FlaskResponse
 
 from .models import ExternalDocumentation
+from .models import RequestBody
 from .models import Server
 from .models import Tag
 from .request import _validate_request
@@ -27,6 +28,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -131,6 +133,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -150,6 +153,7 @@ class APIScaffold:
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
+            request_body: API request body should be either a subclass of BaseModel or None.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
@@ -168,6 +172,7 @@ class APIScaffold:
                     description=description,
                     external_docs=external_docs,
                     operation_id=operation_id,
+                    request_body=request_body,
                     responses=responses,
                     deprecated=deprecated,
                     security=security,
@@ -194,6 +199,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -213,6 +219,7 @@ class APIScaffold:
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
+            request_body: API request body should be either a subclass of BaseModel or None.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
@@ -231,6 +238,7 @@ class APIScaffold:
                     description=description,
                     external_docs=external_docs,
                     operation_id=operation_id,
+                    request_body=request_body,
                     responses=responses,
                     deprecated=deprecated,
                     security=security,
@@ -257,6 +265,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -276,6 +285,7 @@ class APIScaffold:
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
+            request_body: API request body should be either a subclass of BaseModel or None.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
@@ -294,6 +304,7 @@ class APIScaffold:
                     description=description,
                     external_docs=external_docs,
                     operation_id=operation_id,
+                    request_body=request_body,
                     responses=responses,
                     deprecated=deprecated,
                     security=security,
@@ -320,6 +331,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -339,6 +351,7 @@ class APIScaffold:
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
+            request_body: API request body should be either a subclass of BaseModel or None.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
@@ -357,6 +370,7 @@ class APIScaffold:
                     description=description,
                     external_docs=external_docs,
                     operation_id=operation_id,
+                    request_body=request_body,
                     responses=responses,
                     deprecated=deprecated,
                     security=security,
@@ -383,6 +397,7 @@ class APIScaffold:
             description: Optional[str] = None,
             external_docs: Optional[ExternalDocumentation] = None,
             operation_id: Optional[str] = None,
+            request_body: Optional[RequestBody] = None,
             responses: Optional[ResponseDict] = None,
             deprecated: Optional[bool] = None,
             security: Optional[List[Dict[str, List[Any]]]] = None,
@@ -402,6 +417,7 @@ class APIScaffold:
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
+            request_body: API request body should be either a subclass of BaseModel or None.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
@@ -420,6 +436,7 @@ class APIScaffold:
                     description=description,
                     external_docs=external_docs,
                     operation_id=operation_id,
+                    request_body=request_body,
                     responses=responses,
                     deprecated=deprecated,
                     security=security,


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

Goals:

- This allows specifying `requestBody` in endpoints for such cases when the api supports multiple input/output formats
- This also adds the functionality in the other PR https://github.com/luolingchun/flask-openapi3/pull/207
- It also attempts to address https://github.com/luolingchun/flask-openapi3/issues/100

```python
@api.post(
    "/inference",
    request_body={
        "content": {
            # Content type
            "application/json": SAM2InferenceInput,
            "application/bson": SAM2InferenceInput,
        },
        "required": True,
    },
    responses={
        HTTPStatus.OK: {
            "description": "Inference output",
            "content": {
                # Content type
                "application/json": SAM2InferenceOutput,
                "application/bson": SAM2InferenceOutput,
            },
        },
    },
)
@tracer.capture_method
def create_sam2_inference(body: SAM2InferenceInput):
    """Perform inference with SAM2 model.

    Perform inference with SAM2 model using the given input.
    """
    output = perform_sam2_inference(body)
    return respond(output)
```

And also brings support for the swagger docs

![image](https://github.com/user-attachments/assets/82656a78-27f2-4471-b5e5-a9b29f1bc729)
