### PR TITLE
Add support for separate input/output schemas

### DIFF
--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -354,7 +354,7 @@ class OpenAPI(APIScaffold, Flask):
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:
         """
@@ -414,6 +414,9 @@ class OpenAPI(APIScaffold, Flask):
 
             # Store tags
             parse_and_store_tags(tags or [], self.tags, self.tag_names, operation)
+
+            # Cast separate_input_output_schemas to bool
+            separate_input_output_schemas = bool(separate_input_output_schemas)
 
             # Parse response
             get_responses(

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -354,6 +354,7 @@ class OpenAPI(APIScaffold, Flask):
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:
         """
@@ -373,6 +374,7 @@ class OpenAPI(APIScaffold, Flask):
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: maintains distinct schemas for request and response models.
             method: HTTP method for the operation. Defaults to GET.
         """
         if doc_ui is True:
@@ -414,7 +416,12 @@ class OpenAPI(APIScaffold, Flask):
             parse_and_store_tags(tags or [], self.tags, self.tag_names, operation)
 
             # Parse response
-            get_responses(combine_responses, self.components_schemas, operation)
+            get_responses(
+                combine_responses,
+                self.components_schemas,
+                operation,
+                separate_input_output_schemas=separate_input_output_schemas,
+            )
 
             # Convert a route parameter format from /pet/<petId> to /pet/{petId}
             uri = re.sub(r"<([^<:]+:)?", "{", rule).replace(">", "}")
@@ -423,6 +430,11 @@ class OpenAPI(APIScaffold, Flask):
             parse_method(uri, method, self.paths, operation)
 
             # Parse parameters
-            return parse_parameters(func, components_schemas=self.components_schemas, operation=operation)
+            return parse_parameters(
+                func,
+                components_schemas=self.components_schemas,
+                operation=operation,
+                separate_input_output_schemas=separate_input_output_schemas,
+            )
         else:
             return parse_parameters(func, doc_ui=False)

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -33,7 +33,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:
         raise NotImplementedError   # pragma: no cover
@@ -138,7 +138,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             **options: Any
     ) -> Callable:
         """
@@ -158,7 +158,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
-            separate_input_output_schemas: Separate input and output schemas. Default to False.
+            separate_input_output_schemas: Separate input and output schemas.
         """
 
         def decorator(func) -> Callable:
@@ -204,7 +204,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             **options: Any
     ) -> Callable:
         """
@@ -224,7 +224,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
-            separate_input_output_schemas: Separate input and output schemas. Default to False.
+            separate_input_output_schemas: Separate input and output schemas.
         """
 
         def decorator(func) -> Callable:
@@ -270,7 +270,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             **options: Any
     ) -> Callable:
         """
@@ -290,7 +290,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
-            separate_input_output_schemas: Separate input and output schemas. Default to False.
+            separate_input_output_schemas: Separate input and output schemas.
         """
 
         def decorator(func) -> Callable:
@@ -336,7 +336,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             **options: Any
     ) -> Callable:
         """
@@ -356,7 +356,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
-            separate_input_output_schemas: Separate input and output schemas. Default to False.
+            separate_input_output_schemas: Separate input and output schemas.
         """
 
         def decorator(func) -> Callable:
@@ -402,7 +402,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
-            separate_input_output_schemas: bool = False,
+            separate_input_output_schemas: Optional[bool] = None,
             **options: Any
     ) -> Callable:
         """
@@ -422,7 +422,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
-            separate_input_output_schemas: Separate input and output schemas. Default to False.
+            separate_input_output_schemas: Separate input and output schemas.
         """
 
         def decorator(func) -> Callable:

--- a/flask_openapi3/scaffold.py
+++ b/flask_openapi3/scaffold.py
@@ -33,6 +33,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             method: str = HTTPMethod.GET
     ) -> ParametersTuple:
         raise NotImplementedError   # pragma: no cover
@@ -137,6 +138,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             **options: Any
     ) -> Callable:
         """
@@ -156,6 +158,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: Separate input and output schemas. Default to False.
         """
 
         def decorator(func) -> Callable:
@@ -174,6 +177,7 @@ class APIScaffold:
                     servers=servers,
                     openapi_extensions=openapi_extensions,
                     doc_ui=doc_ui,
+                    separate_input_output_schemas=separate_input_output_schemas,
                     method=HTTPMethod.GET
                 )
 
@@ -200,6 +204,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             **options: Any
     ) -> Callable:
         """
@@ -219,6 +224,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: Separate input and output schemas. Default to False.
         """
 
         def decorator(func) -> Callable:
@@ -237,6 +243,7 @@ class APIScaffold:
                     servers=servers,
                     openapi_extensions=openapi_extensions,
                     doc_ui=doc_ui,
+                    separate_input_output_schemas=separate_input_output_schemas,
                     method=HTTPMethod.POST
                 )
 
@@ -263,6 +270,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             **options: Any
     ) -> Callable:
         """
@@ -282,6 +290,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: Separate input and output schemas. Default to False.
         """
 
         def decorator(func) -> Callable:
@@ -300,6 +309,7 @@ class APIScaffold:
                     servers=servers,
                     openapi_extensions=openapi_extensions,
                     doc_ui=doc_ui,
+                    separate_input_output_schemas=separate_input_output_schemas,
                     method=HTTPMethod.PUT
                 )
 
@@ -326,6 +336,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             **options: Any
     ) -> Callable:
         """
@@ -345,6 +356,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: Separate input and output schemas. Default to False.
         """
 
         def decorator(func) -> Callable:
@@ -363,6 +375,7 @@ class APIScaffold:
                     servers=servers,
                     openapi_extensions=openapi_extensions,
                     doc_ui=doc_ui,
+                    separate_input_output_schemas=separate_input_output_schemas,
                     method=HTTPMethod.DELETE
                 )
 
@@ -389,6 +402,7 @@ class APIScaffold:
             servers: Optional[List[Server]] = None,
             openapi_extensions: Optional[Dict[str, Any]] = None,
             doc_ui: bool = True,
+            separate_input_output_schemas: bool = False,
             **options: Any
     ) -> Callable:
         """
@@ -408,6 +422,7 @@ class APIScaffold:
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
             doc_ui: Declares this operation to be shown. Default to True.
+            separate_input_output_schemas: Separate input and output schemas. Default to False.
         """
 
         def decorator(func) -> Callable:
@@ -426,6 +441,7 @@ class APIScaffold:
                     servers=servers,
                     openapi_extensions=openapi_extensions,
                     doc_ui=doc_ui,
+                    separate_input_output_schemas=separate_input_output_schemas,
                     method=HTTPMethod.PATCH
                 )
 

--- a/flask_openapi3/types.py
+++ b/flask_openapi3/types.py
@@ -2,7 +2,7 @@
 # @Author  : llc
 # @Time    : 2023/7/9 15:25
 from http import HTTPStatus
-from typing import Dict, Union, Type, Any, Tuple, Optional
+from typing import Dict, Union, Type, Any, Tuple, Optional, Literal
 
 from pydantic import BaseModel
 
@@ -26,3 +26,5 @@ ParametersTuple = Tuple[
     Optional[Type[BaseModel]],
     Optional[Type[RawModel]]
 ]
+
+NameSuffix = Literal["-Input", "-Output"]

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -388,7 +388,7 @@ def get_responses(
             if definitions:
                 # Add schema definitions to _schemas
                 for name, value in definitions.items():
-                    def_name = normalize_name(original_title, suffix=schema_suffix)
+                    def_name = normalize_name(name, suffix=schema_suffix)
                     _schemas[def_name] = Schema(**value)
 
     components_schemas.update(**_schemas)

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -323,7 +323,9 @@ def parse_body(
 def get_responses(
         responses: ResponseStrKeyDict,
         components_schemas: dict,
-        operation: Operation
+        operation: Operation,
+        *,
+        separate_input_output_schemas: bool,
 ) -> None:
     _responses = {}
     _schemas = {}
@@ -414,6 +416,7 @@ def parse_parameters(
         components_schemas: Optional[Dict] = None,
         operation: Optional[Operation] = None,
         doc_ui: bool = True,
+        separate_input_output_schemas: bool = False,
 ) -> ParametersTuple:
     """
     Parses the parameters of a given function and returns the types for header, cookie, path,
@@ -424,6 +427,7 @@ def parse_parameters(
         components_schemas: Dictionary to store the parsed components schemas (default: None).
         operation: Operation object to populate with parsed parameters (default: None).
         doc_ui: Flag indicating whether to return types for documentation UI (default: True).
+        separate_input_output_schemas: Flag indicating whether to separate input and output schemas (default: False).
 
     Returns:
         Tuple[Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel]]:

--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -636,6 +636,15 @@ def convert_responses_key_to_string(responses: ResponseDict) -> ResponseStrKeyDi
 
 
 def normalize_name(name: str, *, suffix: Optional[NameSuffix] = None) -> str:
+    """Normalize the name by replacing any non-word characters with underscores.
+
+    Args:
+        name: The name to normalize.
+        suffix: An optional suffix to append to the name.
+
+    Returns:
+        The normalized name.
+    """
     result = re.sub(r"[^\w.\-]", "_", name)
     if suffix is not None:
         result = f"{result}{suffix}"

--- a/tests/test_api_blueprint_separate_schemas.py
+++ b/tests/test_api_blueprint_separate_schemas.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2021/5/17 15:25
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel, Field, computed_field
+
+from flask_openapi3 import APIBlueprint, OpenAPI
+from flask_openapi3 import Tag, Info
+
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+api = APIBlueprint(
+    '/book',
+    __name__,
+    url_prefix='/api',
+    separate_input_output_schemas=True,
+)
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+class Status(BaseModel):
+    code: int = Field(0, description='Status Code')
+    message: str = Field('ok', description='Message')
+
+
+class BookModel(BaseModel):
+    age: Optional[int] = Field(..., ge=2, le=4, description='Age')
+    author: Optional[str] = Field(None, min_length=2, max_length=4, description='Author')
+    # price shouldn't be in the response schema
+    price: Optional[Decimal] = Field(None, gt=0, description='Price', exclude=True)
+
+    # isNew shouldn't be in the request schema
+    @computed_field(alias='isNew')
+    def is_new(self) -> bool:
+        return self.age < 2
+
+
+class BookPath(BaseModel):
+    bid: int = Field(..., description='book id')
+
+
+@api.post('/book', responses={"200": Status})
+def create_book(body: BookModel):
+    assert body.age == 3
+    return {"code": 0, "message": "ok"}
+
+
+@api.put('/book/<int:bid>', responses={"200": BookModel}, separate_input_output_schemas=False)
+def update_book__same_schemas(path: BookPath, body: BookModel):
+    assert path.bid == 1
+    assert body.age == 3
+    return body.model_dump()
+
+@api.put('/v2/book/<int:bid>', responses={"200": BookModel})
+def update_book_v2_separate_input_output_schemas(path: BookPath, body: BookModel):
+    assert path.bid == 1
+    assert body.age == 3
+    return body.model_dump()
+
+@api.put('/v3/book/<int:bid>', responses={"200": BookModel}, separate_input_output_schemas=True)
+def update_book_v3_separate_input_output_schemas(path: BookPath, body: BookModel):
+    assert path.bid == 1
+    assert body.age == 3
+    return body.model_dump()
+
+# register api
+app.register_api(api)
+
+def get_response_ref(resp):
+    return resp["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+
+def get_request_ref(req):
+    return req["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json == app.api_doc
+    components = resp.json["components"]
+    paths = resp.json["paths"]
+    assert set(components["schemas"].keys()) == {
+        'BookModel-Input', 'Status-Output', 'ValidationErrorModel', 'BookModel-Output', 'BookModel'
+    }
+    assert set(components["schemas"]["BookModel"]["properties"].keys()) == {"age", "author", "price"}
+    assert set(components["schemas"]["BookModel-Input"]["properties"].keys()) == {"age", "author", "price"}
+    assert set(components["schemas"]["BookModel-Output"]["properties"].keys()) == {"age", "author", "isNew"}
+
+    # create
+    assert get_response_ref(paths["/api/book"]["post"]) == "#/components/schemas/Status-Output"
+    assert get_request_ref(paths["/api/book"]["post"]) == "#/components/schemas/BookModel-Input"
+
+    # update with same schemas
+    assert get_response_ref(paths["/api/book/{bid}"]["put"]) == "#/components/schemas/BookModel"
+    assert get_request_ref(paths["/api/book/{bid}"]["put"]) == "#/components/schemas/BookModel"
+
+    # update with separate schemas (fall back from APIBlueprint level)
+    assert get_response_ref(paths["/api/v2/book/{bid}"]["put"]) == "#/components/schemas/BookModel-Output"
+    assert get_request_ref(paths["/api/v2/book/{bid}"]["put"]) == "#/components/schemas/BookModel-Input"
+
+    # update with separate schemas (specified at API level)
+    assert get_response_ref(paths["/api/v3/book/{bid}"]["put"]) == "#/components/schemas/BookModel-Output"
+    assert get_request_ref(paths["/api/v3/book/{bid}"]["put"]) == "#/components/schemas/BookModel-Input"
+
+def test_post(client):
+    resp = client.post("/api/book", json={"age": 3})
+    assert resp.status_code == 200
+
+
+def test_put(client):
+    resp = client.put("/api/book/1", json={"age": 3})
+    assert resp.status_code == 200
+
+    resp = client.put("/api/book/1", json={"age": 3})
+    assert resp.status_code == 200
+
+    resp = client.put("/api/v2/book/1", json={"age": 3})
+    assert resp.status_code == 200
+
+    resp = client.put("/api/v3/book/1", json={"age": 3})
+    assert resp.status_code == 200

--- a/tests/test_api_blueprint_separate_schemas.py
+++ b/tests/test_api_blueprint_separate_schemas.py
@@ -8,7 +8,6 @@ import pytest
 from pydantic import BaseModel, Field, computed_field
 
 from flask_openapi3 import APIBlueprint, OpenAPI
-from flask_openapi3 import Tag, Info
 
 
 app = OpenAPI(__name__)


### PR DESCRIPTION
Refs:

#211

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.
