### PR TITLE
Support multi content type in request body and responses

### DIFF
--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,2 +1,2 @@
 
---8<-- "LICENSE.rst"
+--8<-- "LICENSE"

--- a/docs/Usage/Request.md
+++ b/docs/Usage/Request.md
@@ -176,3 +176,65 @@ Magic:
 ![](../assets/Snipaste_2022-09-04_10-10-03.png)
 
 More available fields to see [Parameter Object Fixed Fields](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9).
+
+
+## RequestBody
+
+Sometimes, you may need to customize the Content-Type in the request body.
+
+!!! warning
+
+    `request_body` may conflict with the `body` and `form` keyword, so try not to use them together unless the 
+    content type wants to be the same.
+
+```python
+from flask import request
+from pydantic import BaseModel
+
+from flask_openapi import OpenAPI, RequestBody
+from flask_openapi.utils import get_model_schema
+
+app = OpenAPI(__name__)
+
+
+class BookModel(BaseModel):
+    name: str
+    age: int
+
+
+request_body_json = RequestBody(
+    description="The json request body",
+    content={"application/custom+json": {"schema": get_model_schema(BookModel)}},
+)
+
+
+@app.post("/json", request_body=request_body_json)
+def post_json(body: BookModel):
+    print(request.headers.get("content-type"))
+    print(body.model_json_schema())
+    return {"message": "Hello World"}
+
+
+request_body = RequestBody(
+    description="The multi request body",
+    content={
+        "text/plain": {"schema": {"type": "string"}},
+        "text/html": {"schema": {"type": "string"}},
+        "image/png": {"schema": {"type": "string", "format": "binary"}},
+    },
+)
+
+
+@app.post("/text", request_body=request_body)
+def post_csv():
+    print(request.headers.get("content-type"))
+    data = request.data
+    print(data)
+    return {"message": "Hello World"}
+
+
+if __name__ == "__main__":
+    print(app.url_map)
+    app.run()
+
+```

--- a/docs/Usage/Response.md
+++ b/docs/Usage/Response.md
@@ -19,7 +19,6 @@ class BookResponse(BaseModel):
          tags=[book_tag], 
          responses={
              200: BookResponse, 
-             # Version 2.4.0 starts supporting response for dictionary types
              201: {"content": {"text/csv": {"schema": {"type": "string"}}}}
          })
 def get_book(path: BookPath, query: BookBody):

--- a/examples/request_body_demo.py
+++ b/examples/request_body_demo.py
@@ -1,0 +1,48 @@
+from flask import request
+from pydantic import BaseModel
+
+from flask_openapi import OpenAPI, RequestBody
+from flask_openapi.utils import get_model_schema
+
+app = OpenAPI(__name__)
+
+
+class BookModel(BaseModel):
+    name: str
+    age: int
+
+
+request_body_json = RequestBody(
+    description="The json request body",
+    content={"application/custom+json": {"schema": get_model_schema(BookModel)}},
+)
+
+
+@app.post("/json", request_body=request_body_json)
+def post_json(body: BookModel):
+    print(request.headers.get("content-type"))
+    print(body.model_json_schema())
+    return {"message": "Hello World"}
+
+
+request_body = RequestBody(
+    description="The multi request body",
+    content={
+        "text/plain": {"schema": {"type": "string"}},
+        "text/html": {"schema": {"type": "string"}},
+        "image/png": {"schema": {"type": "string", "format": "binary"}},
+    },
+)
+
+
+@app.post("/text", request_body=request_body)
+def post_csv():
+    print(request.headers.get("content-type"))
+    data = request.data
+    print(data)
+    return {"message": "Hello World"}
+
+
+if __name__ == "__main__":
+    print(app.url_map)
+    app.run()

--- a/flask_openapi/blueprint.py
+++ b/flask_openapi/blueprint.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 from flask import Blueprint
 
 from .endpoint import create_view_func
-from .models import ExternalDocumentation, Server, Tag
+from .models import ExternalDocumentation, RequestBody, Server, Tag
 from .types import ParametersTuple, ResponseDict
 from .utils import (
     HTTPMethod,
@@ -110,11 +110,12 @@ class APIBlueprint(Blueprint):
         description: str | None = None,
         external_docs: ExternalDocumentation | dict[str, Any] | None = None,
         operation_id: str | None = None,
-        responses: ResponseDict | None = None,
         deprecated: bool | None = None,
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
+        responses: ResponseDict | None = None,
         doc_ui: bool = True,
         method: str = HTTPMethod.GET,
     ) -> ParametersTuple:
@@ -129,11 +130,12 @@ class APIBlueprint(Blueprint):
             description: A verbose explanation of the operation behavior.
             external_docs: Additional external documentation for this operation.
             operation_id: Unique string used to identify the operation.
-            responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             deprecated: Declares this operation to be deprecated.
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
+            responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             doc_ui: Declares this operation to be shown. Default to True.
         """
         if self.doc_ui is True and doc_ui is True:
@@ -175,6 +177,10 @@ class APIBlueprint(Blueprint):
             tags = (tags or []) + self.abp_tags
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)
 
+            # Parse request body
+            if isinstance(request_body, dict):
+                request_body = RequestBody(**request_body)
+
             # Parse response
             get_responses(combine_responses, self.components_schemas, operation)
 
@@ -185,7 +191,12 @@ class APIBlueprint(Blueprint):
             parse_method(uri, method, self.paths, operation)
 
             # Parse parameters
-            return parse_parameters(func, components_schemas=self.components_schemas, operation=operation)
+            return parse_parameters(
+                func,
+                components_schemas=self.components_schemas,
+                operation=operation,
+                request_body=request_body,
+            )
         else:
             return parse_parameters(func, doc_ui=False)
 
@@ -236,11 +247,11 @@ class APIBlueprint(Blueprint):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.GET,
             )
@@ -277,6 +288,7 @@ class APIBlueprint(Blueprint):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -297,6 +309,7 @@ class APIBlueprint(Blueprint):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -311,11 +324,12 @@ class APIBlueprint(Blueprint):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.POST,
             )
@@ -352,6 +366,7 @@ class APIBlueprint(Blueprint):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -372,6 +387,7 @@ class APIBlueprint(Blueprint):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -386,11 +402,12 @@ class APIBlueprint(Blueprint):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.PUT,
             )
@@ -427,6 +444,7 @@ class APIBlueprint(Blueprint):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -447,6 +465,7 @@ class APIBlueprint(Blueprint):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -461,11 +480,12 @@ class APIBlueprint(Blueprint):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.DELETE,
             )
@@ -502,6 +522,7 @@ class APIBlueprint(Blueprint):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -522,6 +543,7 @@ class APIBlueprint(Blueprint):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -536,11 +558,12 @@ class APIBlueprint(Blueprint):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.PATCH,
             )

--- a/flask_openapi/openapi.py
+++ b/flask_openapi/openapi.py
@@ -17,6 +17,7 @@ from .models import (
     ExternalDocumentation,
     Info,
     OpenAPISpec,
+    RequestBody,
     Schema,
     SecurityScheme,
     Server,
@@ -364,29 +365,11 @@ class OpenAPI(Flask):
         deprecated: bool | None = None,
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
         doc_ui: bool = True,
         method: str = HTTPMethod.GET,
     ) -> ParametersTuple:
-        """
-        Collects OpenAPI specification information for Flask routes and view functions.
-
-        Args:
-            rule: Flask route.
-            func: Flask view_func.
-            tags: Adds metadata to a single tag.
-            summary: A short summary of what the operation does.
-            description: A verbose explanation of the operation behavior.
-            external_docs: Additional external documentation for this operation.
-            operation_id: Unique string used to identify the operation.
-            responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
-            deprecated: Declares this operation to be deprecated.
-            security: A declaration of which security mechanisms can be used for this operation.
-            servers: An alternative server array to service this operation.
-            openapi_extensions: Allows extensions to the OpenAPI Schema.
-            doc_ui: Declares this operation to be shown. Default to True.
-            method: HTTP method for the operation. Defaults to GET.
-        """
         if doc_ui:
             # Convert key to string
             new_responses = convert_responses_key_to_string(responses or {})
@@ -422,6 +405,10 @@ class OpenAPI(Flask):
             # Store tags
             parse_and_store_tags(tags or [], self.tags, self.tag_names, operation)
 
+            # Parse request body
+            if isinstance(request_body, dict):
+                request_body = RequestBody(**request_body)
+
             # Parse response
             get_responses(combine_responses, self.components_schemas, operation)
 
@@ -432,7 +419,12 @@ class OpenAPI(Flask):
             parse_method(uri, method, self.paths, operation)
 
             # Parse parameters
-            return parse_parameters(func, components_schemas=self.components_schemas, operation=operation)
+            return parse_parameters(
+                func,
+                components_schemas=self.components_schemas,
+                operation=operation,
+                request_body=request_body,
+            )
         else:
             return parse_parameters(func, doc_ui=False)
 
@@ -483,11 +475,11 @@ class OpenAPI(Flask):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.GET,
             )
@@ -524,6 +516,7 @@ class OpenAPI(Flask):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -544,6 +537,7 @@ class OpenAPI(Flask):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -558,11 +552,12 @@ class OpenAPI(Flask):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.POST,
             )
@@ -599,6 +594,7 @@ class OpenAPI(Flask):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -619,6 +615,7 @@ class OpenAPI(Flask):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -633,11 +630,12 @@ class OpenAPI(Flask):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.PUT,
             )
@@ -674,6 +672,7 @@ class OpenAPI(Flask):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -694,6 +693,7 @@ class OpenAPI(Flask):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -708,11 +708,12 @@ class OpenAPI(Flask):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.DELETE,
             )
@@ -749,6 +750,7 @@ class OpenAPI(Flask):
         security: list[dict[str, list[Any]]] | None = None,
         servers: list[Server | dict[str, Any]] | None = None,
         openapi_extensions: dict[str, Any] | None = None,
+        request_body: RequestBody | dict[str, Any] | None = None,
         responses: ResponseDict | None = None,
         validate_response: bool | None = None,
         doc_ui: bool = True,
@@ -769,6 +771,7 @@ class OpenAPI(Flask):
             security: A declaration of which security mechanisms can be used for this operation.
             servers: An alternative server array to service this operation.
             openapi_extensions: Allows extensions to the OpenAPI Schema.
+            request_body: Advanced configuration in OpenAPI.
             responses: API responses should be either a subclass of BaseModel, a dictionary, or None.
             validate_response: Verify the response body.
             doc_ui: Declares this operation to be shown. Default to True.
@@ -783,11 +786,12 @@ class OpenAPI(Flask):
                 description=description,
                 external_docs=external_docs,
                 operation_id=operation_id,
-                responses=responses,
                 deprecated=deprecated,
                 security=security,
                 servers=servers,
                 openapi_extensions=openapi_extensions,
+                request_body=request_body,
+                responses=responses,
                 doc_ui=doc_ui,
                 method=HTTPMethod.PATCH,
             )

--- a/flask_openapi/types.py
+++ b/flask_openapi/types.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from .models import Response
 
-_ResponseDictValue = Type[BaseModel] | Response | dict[Any, Any] | None
+_ResponseDictValue = Type[BaseModel] | Response | dict[str, Any] | None
 
 ResponseDict = dict[str | int | HTTPStatus, _ResponseDictValue]
 

--- a/flask_openapi/utils.py
+++ b/flask_openapi/utils.py
@@ -355,24 +355,9 @@ def parse_parameters(
     *,
     components_schemas: dict | None = None,
     operation: Operation | None = None,
+    request_body: RequestBody | None = None,
     doc_ui: bool = True,
 ) -> ParametersTuple:
-    """
-    Parses the parameters of a given function and returns the types for header, cookie, path,
-    query, form, and body parameters. Also populates the Operation object with the parsed parameters.
-
-    Args:
-        func: The function to parse the parameters from.
-        components_schemas: Dictionary to store the parsed components schemas (default: None).
-        operation: Operation object to populate with parsed parameters (default: None).
-        doc_ui: Flag indicating whether to return types for documentation UI (default: True).
-
-    Returns:
-        tuple[Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel], Type[BaseModel]]:
-        The types for header, cookie, path, query, form, and body parameters respectively.
-
-    """
-
     # If components_schemas is None, initialize it as an empty dictionary
     if components_schemas is None:
         components_schemas = dict()
@@ -397,6 +382,7 @@ def parse_parameters(
         return header, cookie, path, query, form, body
 
     parameters = []
+    _request_body = None
 
     if header:
         _parameters, _components_schemas = parse_header(header)
@@ -421,18 +407,18 @@ def parse_parameters(
     if form:
         _content, _components_schemas = parse_form(form)
         components_schemas.update(**_components_schemas)
-        request_body = RequestBody(content=_content, required=True)
-        operation.requestBody = request_body
+        _request_body = RequestBody(content=_content, required=True)
 
     if body:
         _content, _components_schemas = parse_body(body)
         components_schemas.update(**_components_schemas)
-        request_body = RequestBody(content=_content, required=True)
-        operation.requestBody = request_body
+        _request_body = RequestBody(content=_content, required=True)
 
     if parameters:
         # Set the parsed parameters in the operation object
         operation.parameters = parameters
+
+    operation.requestBody = request_body or _request_body
 
     return header, cookie, path, query, form, body
 

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -1,0 +1,78 @@
+import pytest
+from pydantic import BaseModel
+
+from flask_openapi import APIBlueprint, OpenAPI, RequestBody
+from flask_openapi.utils import get_model_schema
+
+app = OpenAPI(__name__)
+api = APIBlueprint("book", __name__, url_prefix="/api")
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+class JsonModel(BaseModel):
+    name: str
+    age: int
+
+
+request_body_json = {
+    "description": "The json request body",
+    "content": {"application/custom+json": {"schema": get_model_schema(JsonModel)}},
+}
+
+request_body = RequestBody(
+    description="The multi request body",
+    content={
+        "text/plain": {"schema": {"type": "string"}},
+        "text/html": {"schema": {"type": "string"}},
+        "image/png": {"schema": {"type": "string", "format": "binary"}},
+    },
+)
+
+
+@app.post("/json", request_body=request_body_json)
+def post_json(body: JsonModel):
+    print(body.model_json_schema())
+    return {"message": "Hello World"}
+
+
+@app.post("/text", request_body=request_body)
+def post_csv():
+    return {"message": "Hello World"}
+
+
+@api.post("/json", request_body=request_body_json)
+def post_api_json():
+    return {"message": "Hello World1"}
+
+
+@api.post("/text", request_body=request_body)
+def post_api_csv():
+    return {"message": "Hello World"}
+
+
+app.register_api(api)
+
+
+def test_get_api_book(client):
+    response = client.get("/openapi/openapi.json")
+    assert response.status_code == 200
+    data = response.json
+    assert list(data["paths"]["/json"]["post"]["requestBody"]["content"].keys()) == ["application/custom+json"]
+    assert set(data["paths"]["/text"]["post"]["requestBody"]["content"].keys()) == {
+        "text/plain",
+        "text/html",
+        "image/png",
+    }
+
+
+def test(client):
+    assert client.post("/json", json={"name": "bob", "age": 3}).status_code == 200
+    assert client.post("/text").status_code == 200
+    assert client.post("/api/json", json={"name": "bob", "age": 3}).status_code == 200
+    assert client.post("/api/text").status_code == 200


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.


Many people have multi content-type needs:

- #100 
- #204 
- #207 
- #208 



