### PR TITLE
Allow url_prefix to be set during API/APIView registration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         flask-version: [ "Flask>=2.0,<3.0", "Flask>=3.0" ]
     env:
       PYTHONPATH: .

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -190,12 +190,18 @@ class APIView:
 
         return decorator
 
-    def register(self, app: "OpenAPI", view_kwargs: Optional[Dict[Any, Any]] = None) -> None:
+    def register(
+            self,
+            app: "OpenAPI",
+            url_prefix: Optional[str] = None,
+            view_kwargs: Optional[Dict[Any, Any]] = None
+    ) -> None:
         """
         Register the API views with the given OpenAPI app.
 
         Args:
             app: An instance of the OpenAPI app.
+            url_prefix: A path to prepend to all the APIView's urls
             view_kwargs: Additional keyword arguments to pass to the API views.
         """
         for rule, (cls, methods) in self.views.items():
@@ -214,6 +220,12 @@ class APIView:
                     view_class=cls,
                     view_kwargs=view_kwargs
                 )
+
+                if url_prefix and self.url_prefix and url_prefix != self.url_prefix:
+                    rule = url_prefix + rule.removeprefix(self.url_prefix)
+                elif url_prefix and not self.url_prefix:
+                    rule = url_prefix.rstrip("/") + "/" + rule.lstrip("/")
+
                 options = {
                     "endpoint": cls.__name__ + "." + method.lower(),
                     "methods": [method.upper()]

--- a/tests/test_url_prefix.py
+++ b/tests/test_url_prefix.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# @Author  : llc
+# @Time    : 2025/1/15 9:58
+import pytest
+
+from flask_openapi3 import APIBlueprint, OpenAPI, APIView
+
+app = OpenAPI(__name__, )
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+
+    return client
+
+
+api1 = APIBlueprint("/book1", __name__, url_prefix="/api")
+api2 = APIBlueprint("/book2", __name__)
+
+
+@api1.get("/book")
+def create_book1():
+    return "ok"
+
+
+@api2.get("/book")
+def create_book2():
+    return "ok"
+
+
+app.register_api(api1, url_prefix="/api1")
+app.register_api(api2, url_prefix="/api2")
+
+api_view1 = APIView(url_prefix="/api")
+api_view2 = APIView()
+
+
+@api_view1.route("/book")
+class BookAPIView:
+    @api_view1.doc(summary="get book")
+    def get(self):
+        return "ok"
+
+
+@api_view2.route("/book")
+class BookAPIView2:
+    @api_view2.doc(summary="get book")
+    def get(self, ):
+        return "ok"
+
+
+app.register_api_view(api_view1, url_prefix="/api3")
+app.register_api_view(api_view2, url_prefix="/api4")
+
+
+def test_openapi(client):
+    resp = client.get("/openapi/openapi.json")
+    _json = resp.json
+    assert "/api1/book" in _json["paths"].keys()
+    assert "/api2/book" in _json["paths"].keys()
+    assert "/api3/book" in _json["paths"].keys()
+    assert "/api4/book" in _json["paths"].keys()


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.


close #205 

todo:
- [ ] Add tests
- [ ] Add docs