### PR TITLE
Schema.maximum type `float` -> `int | float`

### DIFF
--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -19,7 +19,7 @@ class Schema(BaseModel):
     ref: Optional[str] = Field(alias="$ref", default=None)
     title: Optional[str] = None
     multipleOf: Optional[float] = Field(default=None, gt=0.0)
-    maximum: Optional[float] = None
+    maximum: Optional[int | float] = None
     exclusiveMaximum: Optional[float] = None
     minimum: Optional[float] = None
     exclusiveMinimum: Optional[float] = None

--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -19,7 +19,7 @@ class Schema(BaseModel):
     ref: Optional[str] = Field(alias="$ref", default=None)
     title: Optional[str] = None
     multipleOf: Optional[float] = Field(default=None, gt=0.0)
-    maximum: Optional[int | float] = None
+    maximum: Optional[Union[int, float]] = None
     exclusiveMaximum: Optional[float] = None
     minimum: Optional[float] = None
     exclusiveMinimum: Optional[float] = None

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -4,7 +4,7 @@ from typing import Generic, TypeVar, List, Optional, Tuple, Literal
 
 from pydantic import BaseModel, Field
 
-from flask_openapi3 import OpenAPI
+from flask_openapi3 import OpenAPI, Schema
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -571,3 +571,9 @@ def test_prefix_items(request):
  'required': ['my_tuple'],
  'title': 'TupleModel',
  'type': 'object'}
+
+
+def test_schema_bigint(request):
+    max_nr = 9223372036854775807
+    obj = Schema(maximum=max_nr)
+    assert obj.model_dump()["maximum"] == max_nr


### PR DESCRIPTION
Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

Connected to #216