### PR TITLE
fix(models): enable 'populate_by_name' to alias fields correctly

### DIFF
--- a/flask_openapi3/models/media_type.py
+++ b/flask_openapi3/models/media_type.py
@@ -22,5 +22,6 @@ class MediaType(BaseModel):
     encoding: Optional[dict[str, Encoding]] = None
 
     model_config = {
-        "extra": "allow"
+        "extra": "allow",
+        "populate_by_name": True
     }

--- a/flask_openapi3/models/parameter.py
+++ b/flask_openapi3/models/parameter.py
@@ -32,5 +32,6 @@ class Parameter(BaseModel):
     content: Optional[dict[str, MediaType]] = None
 
     model_config = {
-        "extra": "allow"
+        "extra": "allow",
+        "populate_by_name": True
     }

--- a/flask_openapi3/models/path_item.py
+++ b/flask_openapi3/models/path_item.py
@@ -33,5 +33,6 @@ class PathItem(BaseModel):
     parameters: Optional[list[Union[Parameter, Reference]]] = None
 
     model_config = {
-        "extra": "allow"
+        "extra": "allow",
+        "populate_by_name": True
     }

--- a/flask_openapi3/models/reference.py
+++ b/flask_openapi3/models/reference.py
@@ -12,5 +12,6 @@ class Reference(BaseModel):
     ref: str = Field(..., alias="$ref")
 
     model_config = {
-        "extra": "allow"
+        "extra": "allow",
+        "populate_by_name": True
     }

--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -55,6 +55,5 @@ class Schema(BaseModel):
     deprecated: Optional[bool] = None
 
     model_config = {
-        "extra": "allow",
         "populate_by_name": True
     }

--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -53,3 +53,8 @@ class Schema(BaseModel):
     externalDocs: Optional[ExternalDocumentation] = None
     example: Optional[Any] = None
     deprecated: Optional[bool] = None
+
+    model_config = {
+        "extra": "allow",
+        "populate_by_name": True
+    }

--- a/flask_openapi3/models/security_scheme.py
+++ b/flask_openapi3/models/security_scheme.py
@@ -24,5 +24,6 @@ class SecurityScheme(BaseModel):
     openIdConnectUrl: Optional[str] = None
 
     model_config = {
-        "extra": "allow"
+        "extra": "allow",
+        "populate_by_name": True
     }


### PR DESCRIPTION
## Summary

This PR adds `"populate_by_name": True` to the `model_config` for the `SecurityScheme` model

## Context

When creating the application, we can define supported security schemes using plain dicts or the `SecurityScheme` object. The `SecurityScheme` object is more typesafe but must eventually be dumped to JSON in order for the API docs to be generated.

```
app = OpenAPI(
    "app",
    security_schemes={
        "jwt": {"type": "http", "scheme": "bearer"},
        "key": {"type": "apiKey", "in": "header", "name": "X-APP-API-KEY"},
    },
)
```

OR

```
app = OpenAPI(
    "app",
    security_schemes={
        "jwt": SecurityScheme(type="http", scheme="bearer"},
        "key": SecurityScheme(type="apiKey", security_scheme_in="header", name="X-APP-API-KEY"),
    },
)
```

The [`in`](https://spec.openapis.org/oas/v3.1.0#security-scheme-object) keyword is reserved in Python which is why it is currently aliased to `security_scheme_in` however the `model_dump` invocation doesn't actually alias it correctly unless `populate_by_name` is enabled.

```
self.spec_json = self.spec.model_dump(mode="json", by_alias=True, exclude_unset=True, warnings=False)
```

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.
