### PR TITLE
Add validate decorator and ability to delegated validation to that

### DIFF
--- a/flask_openapi3/request.py
+++ b/flask_openapi3/request.py
@@ -204,19 +204,9 @@ def _validate_request(
     return func_kwargs, error
 
 
-def validate(
-    on_success_status: int = 200,
-    exclude_none: bool = False,
-    response_many: bool = False,
-    request_body_many: bool = False,
-    response_by_alias: bool = False,
-    get_json_params: Optional[dict] = None,
-):
+def validate():
     """
-    Decorator for route methods which will validate query, body and form parameters
-    as well as serialize the response (if it derives from pydantic's BaseModel
-    class).
-
+    Decorator to validate the annotated parts of the function and throw and error if applicable.
     """
 
     def decorate(func: Callable) -> Callable:

--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -2,21 +2,21 @@
 # @Author  : llc
 # @Time    : 2022/10/14 16:09
 import typing
-from typing import Optional, Any, Callable
+from typing import Any, Callable, Optional
 
-from .models import ExternalDocumentation
-from .models import Server
-from .models import Tag
+from .models import ExternalDocumentation, Server, Tag
 from .types import ResponseDict
-from .utils import HTTPMethod
-from .utils import convert_responses_key_to_string
-from .utils import get_operation
-from .utils import get_operation_id_for_path
-from .utils import get_responses
-from .utils import parse_and_store_tags
-from .utils import parse_method
-from .utils import parse_parameters
-from .utils import parse_rule
+from .utils import (
+    HTTPMethod,
+    convert_responses_key_to_string,
+    get_operation,
+    get_operation_id_for_path,
+    get_responses,
+    parse_and_store_tags,
+    parse_method,
+    parse_parameters,
+    parse_rule,
+)
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from .openapi import OpenAPI
@@ -24,13 +24,14 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
 class APIView:
     def __init__(
-            self,
-            url_prefix: Optional[str] = None,
-            view_tags: Optional[list[Tag]] = None,
-            view_security: Optional[list[dict[str, list[str]]]] = None,
-            view_responses: Optional[ResponseDict] = None,
-            doc_ui: bool = True,
-            operation_id_callback: Callable = get_operation_id_for_path,
+        self,
+        url_prefix: Optional[str] = None,
+        view_tags: Optional[list[Tag]] = None,
+        view_security: Optional[list[dict[str, list[str]]]] = None,
+        view_responses: Optional[ResponseDict] = None,
+        doc_ui: bool = True,
+        operation_id_callback: Callable = get_operation_id_for_path,
+        delegated_validation: bool = False,
     ):
         """
         Create a class-based view
@@ -60,6 +61,7 @@ class APIView:
         self.components_schemas: dict = dict()
         self.tags: list[Tag] = []
         self.tag_names: list[str] = []
+        self.delegated_validation = delegated_validation
 
     def route(self, rule: str):
         """Decorator for view class"""
@@ -86,9 +88,7 @@ class APIView:
                 # Update operation_id
                 if not cls_method.operation.operationId:
                     cls_method.operation.operationId = self.operation_id_callback(
-                        name=cls_method.__qualname__,
-                        path=rule,
-                        method=method
+                        name=cls_method.__qualname__, path=rule, method=method
                     )
 
             # Convert route parameters from {param} to <param>
@@ -100,19 +100,19 @@ class APIView:
         return wrapper
 
     def doc(
-            self,
-            *,
-            tags: Optional[list[Tag]] = None,
-            summary: Optional[str] = None,
-            description: Optional[str] = None,
-            external_docs: Optional[ExternalDocumentation] = None,
-            operation_id: Optional[str] = None,
-            responses: Optional[ResponseDict] = None,
-            deprecated: Optional[bool] = None,
-            security: Optional[list[dict[str, list[Any]]]] = None,
-            servers: Optional[list[Server]] = None,
-            openapi_extensions: Optional[dict[str, Any]] = None,
-            doc_ui: bool = True
+        self,
+        *,
+        tags: Optional[list[Tag]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        external_docs: Optional[ExternalDocumentation] = None,
+        operation_id: Optional[str] = None,
+        responses: Optional[ResponseDict] = None,
+        deprecated: Optional[bool] = None,
+        security: Optional[list[dict[str, list[Any]]]] = None,
+        servers: Optional[list[Server]] = None,
+        openapi_extensions: Optional[dict[str, Any]] = None,
+        doc_ui: bool = True,
     ) -> Callable:
         """
         Decorator for view method.
@@ -145,10 +145,7 @@ class APIView:
 
             # Create operation
             operation = get_operation(
-                func,
-                summary=summary,
-                description=description,
-                openapi_extensions=openapi_extensions
+                func, summary=summary, description=description, openapi_extensions=openapi_extensions
             )
 
             # Set external docs
@@ -176,11 +173,7 @@ class APIView:
             parse_and_store_tags(tags, self.tags, self.tag_names, operation)
 
             # Parse parameters
-            parse_parameters(
-                func,
-                components_schemas=self.components_schemas,
-                operation=operation
-            )
+            parse_parameters(func, components_schemas=self.components_schemas, operation=operation)
 
             # Parse response
             get_responses(combine_responses, self.components_schemas, operation)
@@ -191,10 +184,7 @@ class APIView:
         return decorator
 
     def register(
-            self,
-            app: "OpenAPI",
-            url_prefix: Optional[str] = None,
-            view_kwargs: Optional[dict[Any, Any]] = None
+        self, app: "OpenAPI", url_prefix: Optional[str] = None, view_kwargs: Optional[dict[Any, Any]] = None
     ) -> None:
         """
         Register the API views with the given OpenAPI app.
@@ -218,7 +208,8 @@ class APIView:
                     body,
                     raw,
                     view_class=cls,
-                    view_kwargs=view_kwargs
+                    view_kwargs=view_kwargs,
+                    delegated_validation=self.delegated_validation,
                 )
 
                 if url_prefix and self.url_prefix and url_prefix != self.url_prefix:
@@ -226,8 +217,5 @@ class APIView:
                 elif url_prefix and not self.url_prefix:
                     rule = url_prefix.rstrip("/") + "/" + rule.lstrip("/")
 
-                options = {
-                    "endpoint": cls.__name__ + "." + method.lower(),
-                    "methods": [method.upper()]
-                }
+                options = {"endpoint": cls.__name__ + "." + method.lower(), "methods": [method.upper()]}
                 app.add_url_rule(rule, view_func=view_func, **options)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,69 +1,67 @@
 [project]
-name = "flask-openapi3"
-description = "Generate REST API and OpenAPI documentation for your Flask project."
-readme = "README.md"
-license = { text = "MIT" }
-maintainers = [{ name = "llc", email = "luolingchun@outlook.com" }]
 classifiers = [
-    # "Development Status :: 1 - Planning",
-    # "Development Status :: 2 - Pre-Alpha",
-    # "Development Status :: 3 - Alpha",
-    # "Development Status :: 4 - Beta",
-    "Development Status :: 5 - Production/Stable",
-    # "Development Status :: 6 - Mature",
-    # "Development Status :: 7 - Inactive",
-    "Environment :: Web Environment",
-    "Framework :: Flask",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
+  # "Development Status :: 1 - Planning",
+  # "Development Status :: 2 - Pre-Alpha",
+  # "Development Status :: 3 - Alpha",
+  # "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable", # "Development Status :: 6 - Mature",
+  # "Development Status :: 7 - Inactive",
+  "Environment :: Web Environment",
+  "Framework :: Flask",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9"
 dependencies = ["Flask>=2.0", "pydantic>=2.4"]
+description = "Generate REST API and OpenAPI documentation for your Flask project."
 dynamic = ["version"]
+license = {text = "MIT"}
+maintainers = [{name = "llc", email = "luolingchun@outlook.com"}]
+name = "flask-openapi3"
+readme = "README.md"
+requires-python = ">=3.9"
 
 [project.urls]
-Homepage = "https://github.com/luolingchun/flask-openapi3"
 Documentation = "https://luolingchun.github.io/flask-openapi3"
+Homepage = "https://github.com/luolingchun/flask-openapi3"
 
 [project.optional-dependencies]
-yaml = ["pyyaml"]
 async = ["asgiref >= 3.2"]
 dotenv = ["python-dotenv"]
 email = ["email-validator"]
+yaml = ["pyyaml"]
 # ui templates
-swagger = ["flask-openapi3-swagger"]
-redoc = ["flask-openapi3-redoc"]
+elements = ["flask-openapi3-elements"]
 rapidoc = ["flask-openapi3-rapidoc"]
 rapipdf = ["flask-openapi3-rapipdf"]
+redoc = ["flask-openapi3-redoc"]
 scalar = ["flask-openapi3-scalar"]
-elements = ["flask-openapi3-elements"]
-
+swagger = ["flask-openapi3-swagger"]
 
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = ["hatchling"]
 
 [tool.hatch.version]
 path = "flask_openapi3/__version__.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "/flask_openapi3",
-    "/examples",
-    "/requirements",
-    "/tests",
-    "/CHANGELOG.md",
-    "/CONTRIBUTING.md",
-    "/LICENSE.rst"
+  "/flask_openapi3",
+  "/examples",
+  "/requirements",
+  "/tests",
+  "/CHANGELOG.md",
+  "/CONTRIBUTING.md",
+  "/LICENSE.rst",
 ]
 
 [tool.ruff]
@@ -72,12 +70,14 @@ line-length = 120
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 
+[tool.ruff.format]
+quote-style = "double"
+
 [tool.mypy]
 files = "src"
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["pydantic_core.*", "devtools.*"]
 follow_imports = "skip"
 ignore_missing_imports = true
-
+module = ["pydantic_core.*", "devtools.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,67 +1,69 @@
 [project]
-classifiers = [
-  # "Development Status :: 1 - Planning",
-  # "Development Status :: 2 - Pre-Alpha",
-  # "Development Status :: 3 - Alpha",
-  # "Development Status :: 4 - Beta",
-  "Development Status :: 5 - Production/Stable", # "Development Status :: 6 - Mature",
-  # "Development Status :: 7 - Inactive",
-  "Environment :: Web Environment",
-  "Framework :: Flask",
-  "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
-dependencies = ["Flask>=2.0", "pydantic>=2.4"]
-description = "Generate REST API and OpenAPI documentation for your Flask project."
-dynamic = ["version"]
-license = {text = "MIT"}
-maintainers = [{name = "llc", email = "luolingchun@outlook.com"}]
 name = "flask-openapi3"
+description = "Generate REST API and OpenAPI documentation for your Flask project."
 readme = "README.md"
+license = { text = "MIT" }
+maintainers = [{ name = "llc", email = "luolingchun@outlook.com" }]
+classifiers = [
+    # "Development Status :: 1 - Planning",
+    # "Development Status :: 2 - Pre-Alpha",
+    # "Development Status :: 3 - Alpha",
+    # "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
+    # "Development Status :: 6 - Mature",
+    # "Development Status :: 7 - Inactive",
+    "Environment :: Web Environment",
+    "Framework :: Flask",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 requires-python = ">=3.9"
+dependencies = ["Flask>=2.0", "pydantic>=2.4"]
+dynamic = ["version"]
 
 [project.urls]
-Documentation = "https://luolingchun.github.io/flask-openapi3"
 Homepage = "https://github.com/luolingchun/flask-openapi3"
+Documentation = "https://luolingchun.github.io/flask-openapi3"
 
 [project.optional-dependencies]
+yaml = ["pyyaml"]
 async = ["asgiref >= 3.2"]
 dotenv = ["python-dotenv"]
 email = ["email-validator"]
-yaml = ["pyyaml"]
 # ui templates
-elements = ["flask-openapi3-elements"]
+swagger = ["flask-openapi3-swagger"]
+redoc = ["flask-openapi3-redoc"]
 rapidoc = ["flask-openapi3-rapidoc"]
 rapipdf = ["flask-openapi3-rapipdf"]
-redoc = ["flask-openapi3-redoc"]
 scalar = ["flask-openapi3-scalar"]
-swagger = ["flask-openapi3-swagger"]
+elements = ["flask-openapi3-elements"]
+
 
 [build-system]
-build-backend = "hatchling.build"
 requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.hatch.version]
 path = "flask_openapi3/__version__.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/flask_openapi3",
-  "/examples",
-  "/requirements",
-  "/tests",
-  "/CHANGELOG.md",
-  "/CONTRIBUTING.md",
-  "/LICENSE.rst",
+    "/flask_openapi3",
+    "/examples",
+    "/requirements",
+    "/tests",
+    "/CHANGELOG.md",
+    "/CONTRIBUTING.md",
+    "/LICENSE.rst"
 ]
 
 [tool.ruff]
@@ -70,14 +72,12 @@ line-length = 120
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 
-[tool.ruff.format]
-quote-style = "double"
-
 [tool.mypy]
 files = "src"
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
+module = ["pydantic_core.*", "devtools.*"]
 follow_imports = "skip"
 ignore_missing_imports = true
-module = ["pydantic_core.*", "devtools.*"]
+

--- a/tests/test_empty_body.py
+++ b/tests/test_empty_body.py
@@ -2,12 +2,16 @@
 # @Author  : llc
 # @Time    : 2021/12/1 9:39
 
+from functools import wraps
+
 import pytest
+from flask import jsonify, request
 from pydantic import BaseModel
 
 from flask_openapi3 import Info, OpenAPI
+from flask_openapi3.request import validate
 
-info = Info(title='book API', version='1.0.0')
+info = Info(title="book API", version="1.0.0")
 
 app = OpenAPI(__name__, info=info)
 app.config["TESTING"] = True
@@ -21,6 +25,10 @@ class CreateBookBody(BaseModel):
     }
 
 
+class BookBody(BaseModel):
+    name: str
+
+
 @pytest.fixture
 def client():
     client = app.test_client()
@@ -28,13 +36,76 @@ def client():
     return client
 
 
-@app.post('/book')
+@app.post("/book")
 def create_book(body: CreateBookBody):
     print(body.model_dump())
     return {"code": 0, "message": "ok"}
 
 
+def check_header(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if request.headers.get("foo") != "bar":
+            return jsonify({"error": "Access Denied"}), 400
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@app.post("/book2", delegated_validation=True)
+@check_header
+@validate()
+def create_book_validate(body: BookBody):
+    print(body.model_dump())
+    return {"code": 0, "message": "ok"}
+
+
+@app.post("/book3")
+@check_header
+def create_book_validate_alt(body: BookBody):
+    print(body.model_dump())
+    return {"code": 0, "message": "ok"}
+
+
 def test_post(client):
-    resp = client.post("/book", json={'aaa': 111, 'bbb': 222})
+    resp = client.post("/book", json={"aaa": 111, "bbb": 222})
     print(resp.json)
     assert resp.status_code == 200
+
+
+def test_post_auth_check(client):
+    resp = client.post("/book2", json={"bla": 111}, headers={"nope": "nope"})
+    print(resp.json)
+    assert resp.status_code == 400
+    assert resp.json == {"error": "Access Denied"}
+
+    resp = client.post("/book2", json={"bla": 111}, headers={"foo": "bar"})
+    print(resp.json)
+    assert resp.status_code == 422
+    assert resp.json == [
+        {
+            "type": "missing",
+            "loc": ["name"],
+            "msg": "Field required",
+            "input": {"bla": 111},
+            "url": "https://errors.pydantic.dev/2.11/v/missing",
+        }
+    ]
+
+
+def test_post_auth_check_alternate(client):
+    resp = client.post("/book3", json={"bla": 111}, headers={"nope": "nope"})
+    assert resp.status_code == 400
+    assert resp.json == {"error": "Access Denied"}
+
+    resp = client.post("/book3", json={"bla": 111}, headers={"foo": "bar"})
+    assert resp.status_code == 422
+    assert resp.json == [
+        {
+            "type": "missing",
+            "loc": ["name"],
+            "msg": "Field required",
+            "input": {"bla": 111},
+            "url": "https://errors.pydantic.dev/2.11/v/missing",
+        }
+    ]


### PR DESCRIPTION
Checklist:

- [X] Run `pytest tests` and no failed.
- [X] Run `ruff check flask_openapi3 tests examples` and no failed.
- [X] Run `mypy flask_openapi3` and no failed.
- [X] Run `mkdocs serve` and no failed.

@luolingchun This is based on your `Delay-throwing-validation-error` branch. But adds a decorator that can be used.

Some explanation. We use `flask-pydantic` which has `@validate` decorator, I copied and adjusted that to your code base. 

This change is backward compatible, so existing users are not effected. But as seen in adjusted tests, you can pass a `delegated_validation=True` and then use the `@validate` decorator for full control.

The change in your branch won't resolve the situation, it now calls the function with missing arguments causing various other issues.