### PR TITLE
Fixes issue where register_api isn't idempotent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before submitting pr, you need to complete the following steps:
 1. Install requirements
 
     ```bash
-    pip install -U flask pydantic
+    pip install -U flask pydantic pyyaml pytest ruff mypy
     ```
 
 2. Running the tests

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -347,8 +347,10 @@ class OpenAPI(APIScaffold, Flask):
         # Update paths with the APIView's paths
         if url_prefix and api_view.url_prefix and url_prefix != api_view.url_prefix:
             api_view.paths = {url_prefix + k.removeprefix(api_view.url_prefix): v for k, v in api_view.paths.items()}
+            api_view.url_prefix = url_prefix
         elif url_prefix and not api_view.url_prefix:
             api_view.paths = {url_prefix.rstrip("/") + "/" + k.lstrip("/"): v for k, v in api_view.paths.items()}
+            api_view.url_prefix = url_prefix
         self.paths.update(**api_view.paths)
 
         # Update component schemas with the APIView's component schemas

--- a/flask_openapi3/openapi.py
+++ b/flask_openapi3/openapi.py
@@ -306,8 +306,10 @@ class OpenAPI(APIScaffold, Flask):
         url_prefix = options.get("url_prefix")
         if url_prefix and api.url_prefix and url_prefix != api.url_prefix:
             api.paths = {url_prefix + k.removeprefix(api.url_prefix): v for k, v in api.paths.items()}
+            api.url_prefix = url_prefix
         elif url_prefix and not api.url_prefix:
             api.paths = {url_prefix.rstrip("/") + "/" + k.lstrip("/"): v for k, v in api.paths.items()}
+            api.url_prefix = url_prefix
         self.paths.update(**api.paths)
 
         # Update component schemas with the APIBlueprint's component schemas


### PR DESCRIPTION
In a situation where we may instantiate multiple apps that register the same blueprint, this change updates register_api to always update the APIBlueprint's instance variables to the same values no matter how many times it is invoked.

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.


For the fix here, I opted to update an additional field in the api rather than not updating the API because I thought that it would be helpful to have the proper updated `api.paths` field. I'm open to other approaches as well!