### PR TITLE
Fix ValidationError schema to match Pydantic v2 format

### DIFF
--- a/flask_openapi3/models/validation_error.py
+++ b/flask_openapi3/models/validation_error.py
@@ -7,14 +7,16 @@ from pydantic import BaseModel, Field
 
 
 class ValidationErrorModel(BaseModel):
-    # More information: https://docs.pydantic.dev/latest/usage/models/#error-handling
-    loc: Optional[list[str]] = Field(None, title="Location", description="the error's location as a list. ")
-    msg: Optional[str] = Field(None, title="Message", description="a computer-readable identifier of the error type.")
-    type_: Optional[str] = Field(None, title="Error Type", description="a human readable explanation of the error.")
+    # More information: https://docs.pydantic.dev/latest/concepts/models/#error-handling
+    type: str = Field(..., title="Error Type", description="A computer-readable identifier of the error type.")
+    loc: list[Any] = Field(..., title="Location", description="The error's location as a list.")
+    msg: str = Field(..., title="Message", description="A human readable explanation of the error.")
+    input: Any = Field(..., title="Input", description="The input provided for validation.")
+    url: Optional[str] = Field(None, title="URL", description="The URL to further information about the error.")
     ctx: Optional[dict[str, Any]] = Field(
         None,
         title="Error context",
-        description="an optional object which contains values required to render the error message."
+        description="An optional object which contains values required to render the error message.",
     )
 
 

--- a/tests/test_pydantic_v2_validation_error.py
+++ b/tests/test_pydantic_v2_validation_error.py
@@ -1,0 +1,101 @@
+import pytest
+from pydantic import BaseModel, Field
+
+from flask_openapi3 import OpenAPI
+
+app = OpenAPI(__name__)
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+    return client
+
+
+class LoginRequest(BaseModel):
+    email: str = Field(..., description="User email")
+    password: str = Field(..., description="User password")
+
+
+@app.post("/login")
+def login(body: LoginRequest):
+    return {"message": f"Login successful for {body.email}"}
+
+
+def test_pydantic_v2_schema(client):
+    resp = client.get("/openapi/openapi.json")
+    assert resp.status_code == 200
+
+    schemas = resp.json["components"]["schemas"]
+    assert "ValidationErrorModel" in schemas
+
+    validation_error_schema = schemas["ValidationErrorModel"]
+    properties = validation_error_schema["properties"]
+
+    assert "type" in properties
+    assert "loc" in properties
+    assert "msg" in properties
+    assert "input" in properties
+    assert "url" in properties
+    assert "ctx" in properties
+
+    assert properties["type"]["type"] == "string"
+    assert properties["loc"]["type"] == "array"
+    assert properties["msg"]["type"] == "string"
+
+    required_fields = validation_error_schema.get("required", [])
+    assert "type" in required_fields
+    assert "loc" in required_fields
+    assert "msg" in required_fields
+    assert "input" in required_fields
+    assert "ctx" not in required_fields
+
+
+def test_validation_error_format(client):
+    resp = client.post(
+        "/login",
+        json={"invalid_field": "test"},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 422
+
+    errors = resp.json
+    assert isinstance(errors, list)
+    assert len(errors) > 0
+
+    error = errors[0]
+    assert "type" in error
+    assert "loc" in error
+    assert "msg" in error
+    assert "input" in error
+
+    assert isinstance(error["type"], str)
+    assert isinstance(error["loc"], list)
+    assert isinstance(error["msg"], str)
+    assert error["type"] in ["missing", "string_type", "value_error", "extra_forbidden"]
+
+
+def test_missing_field_error(client):
+    resp = client.post(
+        "/login",
+        json={},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 422
+
+    errors = resp.json
+    assert len(errors) >= 2
+
+    email_error = None
+    for error in errors:
+        if error.get("loc") == ["email"]:
+            email_error = error
+            break
+
+    assert email_error is not None
+    assert email_error["type"] == "missing"
+    assert email_error["msg"] == "Field required"
+    assert email_error["input"] == {}

--- a/tests/test_pydantic_validation_error.py
+++ b/tests/test_pydantic_validation_error.py
@@ -23,7 +23,7 @@ def login(body: LoginRequest):
     return {"message": f"Login successful for {body.email}"}
 
 
-def test_pydantic_v2_schema(client):
+def test_pydantic_validation_error_schema(client):
     resp = client.get("/openapi/openapi.json")
     assert resp.status_code == 200
 
@@ -52,7 +52,7 @@ def test_pydantic_v2_schema(client):
     assert "ctx" not in required_fields
 
 
-def test_validation_error_format(client):
+def test_pydantic_validation_error_response(client):
     resp = client.post(
         "/login",
         json={"invalid_field": "test"},
@@ -77,7 +77,7 @@ def test_validation_error_format(client):
     assert error["type"] in ["missing", "string_type", "value_error", "extra_forbidden"]
 
 
-def test_missing_field_error(client):
+def test_pydantic_missing_field_error_response(client):
     resp = client.post(
         "/login",
         json={},


### PR DESCRIPTION
# Fix ValidationError schema to match Pydantic v2 format

## Related Issue
Fixes #231 

## Problem Description
The ValidationError schema in OpenAPI documentation doesn't match the actual Pydantic v2 validation error responses, causing confusion for API consumers.

### Before (inconsistent):
**OpenAPI Schema:**
```json
{
  "ctx": null,
  "loc": null, 
  "msg": null,
  "type_": null
}
```

**Actual Response:**
```json
{
  "type": "missing",
  "loc": ["email"],
  "msg": "Field required", 
  "input": {"invalid_field": "test"},
  "url": "https://errors.pydantic.dev/2.11/v/missing"
}
```

### After (consistent):
Both OpenAPI schema AND actual responses now use the same Pydantic v2 format! ✅

## Solution
Updated `ValidationErrorModel` in `flask_openapi3/models/validation_error.py` to align with Pydantic v2 error format:

- **Changed `type_` → `type`** (correct Pydantic v2 field name)
- **Added `input` field** (required in Pydantic v2)  
- **Added `url` field** (present in Pydantic v2 responses)
- **Made core fields required** (`type`, `loc`, `msg`, `input`)
- **Updated field descriptions** to match Pydantic v2 documentation

## Changes Made

### Files Modified:
- `flask_openapi3/models/validation_error.py` - Updated ValidationErrorModel
- `tests/test_pydantic_validation_error.py` - New comprehensive tests

### Tests Added:
- `test_pydantic_validation_error_schema()` - Validates OpenAPI schema has correct fields
- `test_pydantic_validation_error_response()` - Verifies actual responses match Pydantic schema
- `test_pydantic_missing_field_error_response()` - Tests specific validation error scenarios

## Validation

### Tests and Code quality:
- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.

### Real-world Testing:
- [x] Tested in a real project using `pip install -e .`
- [x] OpenAPI docs now show correct schema
- [x] Validation errors match documented format
- [x] Existing functionality preserved

## Breaking Changes
None - this only fixes the OpenAPI schema documentation to match existing runtime behavior.
