### PR TITLE
[#240] Fix for br tag rendering

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -78,9 +78,9 @@ def get_operation(
 
     # Determine the summary and description based on provided arguments or docstring
     if summary is None:
-        doc_description = lines[0] if len(lines) == 0 else "</br>".join(lines[1:])
+        doc_description = lines[0] if len(lines) == 0 else "<br/>".join(lines[1:])
     else:
-        doc_description = "</br>".join(lines)
+        doc_description = "<br/>".join(lines)
 
     summary = summary or doc_summary
     description = description or doc_description

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -97,6 +97,15 @@ def delete_book(path: BookPath):
     return {"code": 0, "message": "ok"}
 
 
+@api.get("/book/<int:bid>")
+def get_book(path: BookPath):
+    """Get Book
+    Here is a book
+    Here's another line in the description
+    """
+    return {"title": "test", "Author": "author"}
+
+
 # register api
 app.register_api(api)
 
@@ -107,6 +116,8 @@ def test_openapi(client):
     assert resp.json == app.api_doc
     assert resp.json["paths"]["/api/book/{bid}"]["put"]["operationId"] == "update"
     assert resp.json["paths"]["/api/book/{bid}"]["delete"]["operationId"] == "delete_book"
+    expected_description = "Here is a book<br/>Here's another line in the description"
+    assert resp.json["paths"]["/api/book/{bid}"]["get"]["description"] == expected_description
 
 
 def test_post(client):


### PR DESCRIPTION
Updates the br tag rendering to properly output <br/> instead of </br>

Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi3 tests examples` and no failed.
- [ ] Run `ruff format flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.
