### PR TITLE
Allow const to be Any type

### DIFF
--- a/flask_openapi3/models/schema.py
+++ b/flask_openapi3/models/schema.py
@@ -54,6 +54,6 @@ class Schema(BaseModel):
     externalDocs: ExternalDocumentation | None = None
     example: Any | None = None
     deprecated: bool | None = None
-    const: str | None = None
+    const: Any | None = None
 
     model_config = {"populate_by_name": True}


### PR DESCRIPTION
Trying to create a schema that uses `const` with a non-string value crashes

Per the specification:
> The value of this keyword MAY be of any type, including null.

https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3

Checklist:

- [x] Run `pytest tests` and no failed.
- [x] Run `ruff check flask_openapi3 tests examples` and no failed.
- [x] Run `ruff format flask_openapi3 tests examples` and no failed.
- [x] Run `mypy flask_openapi3` and no failed.
- [x] Run `mkdocs serve` and no failed.
