### PR TITLE
Fix no attribute 'validate_response'

### DIFF
--- a/flask_openapi3/view.py
+++ b/flask_openapi3/view.py
@@ -204,10 +204,7 @@ class APIView:
         for rule, (cls, methods) in self.views.items():
             for method in methods:
                 func = getattr(cls, method.lower())
-                if func.validate_response is not None:
-                    _validate_response = func.validate_response
-                else:
-                    _validate_response = self.validate_response
+                _validate_response = getattr(func, "validate_response", None) or self.validate_response
                 header, cookie, path, query, form, body, raw = parse_parameters(func, doc_ui=False)
                 view_func = app.create_view_func(
                     func,


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi3 tests examples` and no failed.
- [ ] Run `ruff format flask_openapi3 tests examples` and no failed.
- [ ] Run `mypy flask_openapi3` and no failed.
- [ ] Run `mkdocs serve` and no failed.
