### PR TITLE
Rename flask-openapi3 to flask-openapi

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: mkdocs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ v4.x ]
 
 jobs:
   docs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,11 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --upgrade --group build --all-extras
+        run: uv sync
 
       - name: Build and publish
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          uv run python -m build
-          uv run twine upload dist/*
+          uv build
+          uv publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,14 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ v4.x ]
     paths-ignore:
       - "docs/**"
       - "*.md"
       - "*.rst"
 
   pull_request:
-    branches: [ master ]
+    branches: [ v4.x ]
     paths-ignore:
       - "docs/**"
       - "*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,20 +133,20 @@
 - Upgrade Swagger UI v5.9.0.
 - Upgrade Redoc v2.1.2
 - Update RapiDoc 9.3.4.
-- [#105](https://github.com/luolingchun/flask-openapi3/pull/105) Supports valid properties only. Thanks, @ota42y.
-- [#106](https://github.com/luolingchun/flask-openapi3/pull/106) Bugfix for parameter object. Thanks, @ota42y.
-- [#107](https://github.com/luolingchun/flask-openapi3/pull/107) Bugfix for generics class. Thanks, @ota42y.
-- [#114](https://github.com/luolingchun/flask-openapi3/pull/114) Support Flask 3.0.
-- [#118](https://github.com/luolingchun/flask-openapi3/discussions/118) Fix missed components schemas in
+- [#105](https://github.com/luolingchun/flask-openapi/pull/105) Supports valid properties only. Thanks, @ota42y.
+- [#106](https://github.com/luolingchun/flask-openapi/pull/106) Bugfix for parameter object. Thanks, @ota42y.
+- [#107](https://github.com/luolingchun/flask-openapi/pull/107) Bugfix for generics class. Thanks, @ota42y.
+- [#114](https://github.com/luolingchun/flask-openapi/pull/114) Support Flask 3.0.
+- [#118](https://github.com/luolingchun/flask-openapi/discussions/118) Fix missed components schemas in
   ValidationErrorModel. Thanks, @SeFeX.
-- [#122](https://github.com/luolingchun/flask-openapi3/issues/122) Skip 422 response non parameters. Thanks, @Danielsn1.
+- [#122](https://github.com/luolingchun/flask-openapi/issues/122) Skip 422 response non parameters. Thanks, @Danielsn1.
 
 ## v3.0.0rc2 2023-10-03
 
-- [#105](https://github.com/luolingchun/flask-openapi3/pull/105) Supports valid properties only. Thanks, @ota42y.
-- [#106](https://github.com/luolingchun/flask-openapi3/pull/106) Bugfix for parameter object. Thanks, @ota42y.
-- [#107](https://github.com/luolingchun/flask-openapi3/pull/107) Bugfix for generics class. Thanks, @ota42y.
-- [#114](https://github.com/luolingchun/flask-openapi3/pull/114) Support Flask 3.0.
+- [#105](https://github.com/luolingchun/flask-openapi/pull/105) Supports valid properties only. Thanks, @ota42y.
+- [#106](https://github.com/luolingchun/flask-openapi/pull/106) Bugfix for parameter object. Thanks, @ota42y.
+- [#107](https://github.com/luolingchun/flask-openapi/pull/107) Bugfix for generics class. Thanks, @ota42y.
+- [#114](https://github.com/luolingchun/flask-openapi/pull/114) Support Flask 3.0.
 
 ## v3.0.0rc1 2023-09-03
 
@@ -162,45 +162,45 @@
 
 ## v2.5.4 2023-10-22
 
-- [#118](https://github.com/luolingchun/flask-openapi3/discussions/118) Fix missed components schemas in
+- [#118](https://github.com/luolingchun/flask-openapi/discussions/118) Fix missed components schemas in
   ValidationErrorModel. Thanks, @SeFeX.
-- [#122](https://github.com/luolingchun/flask-openapi3/issues/122) Skip 422 response non parameters. Thanks, @Danielsn1.
+- [#122](https://github.com/luolingchun/flask-openapi/issues/122) Skip 422 response non parameters. Thanks, @Danielsn1.
 
 ## v2.5.3 2023-10-03
 
-- [#105](https://github.com/luolingchun/flask-openapi3/pull/105) Supports valid properties only. Thanks, @ota42y.
-- [#106](https://github.com/luolingchun/flask-openapi3/pull/106) Bugfix for parameter object. Thanks, @ota42y.
-- [#107](https://github.com/luolingchun/flask-openapi3/pull/107) Bugfix for generics class. Thanks, @ota42y.
+- [#105](https://github.com/luolingchun/flask-openapi/pull/105) Supports valid properties only. Thanks, @ota42y.
+- [#106](https://github.com/luolingchun/flask-openapi/pull/106) Bugfix for parameter object. Thanks, @ota42y.
+- [#107](https://github.com/luolingchun/flask-openapi/pull/107) Bugfix for generics class. Thanks, @ota42y.
 
 ## v2.5.2 2023-08-13
 
-- [#97](https://github.com/luolingchun/flask-openapi3/issues/97) Fix response miss description. Thanks, @tekrei.
+- [#97](https://github.com/luolingchun/flask-openapi/issues/97) Fix response miss description. Thanks, @tekrei.
 
 ## v2.5.1 2023-08-07
 
-- [#95](https://github.com/luolingchun/flask-openapi3/pull/95) Added ability to deserialize complex form parameter
+- [#95](https://github.com/luolingchun/flask-openapi/pull/95) Added ability to deserialize complex form parameter
   objects. Thanks, @BlackGad.
 
 ## v2.5.0 2023-08-02
 
-- [#79](https://github.com/luolingchun/flask-openapi3/discussions/79) Support `by_alias` in Model Config. Thanks,
+- [#79](https://github.com/luolingchun/flask-openapi/discussions/79) Support `by_alias` in Model Config. Thanks,
   @candleindark.
-- [#82](https://github.com/luolingchun/flask-openapi3/issues/82) Fix parameter in url_prefix. Thanks, @riedgar-ms.
-- [#83](https://github.com/luolingchun/flask-openapi3/pull/83) Be able to change 422 validation errors to other http
+- [#82](https://github.com/luolingchun/flask-openapi/issues/82) Fix parameter in url_prefix. Thanks, @riedgar-ms.
+- [#83](https://github.com/luolingchun/flask-openapi/pull/83) Be able to change 422 validation errors to other http
   response status. Thanks, @CostcoFanboy.
-- [#86](https://github.com/luolingchun/flask-openapi3/issues/86) Responses key supports both string, int, and
+- [#86](https://github.com/luolingchun/flask-openapi/issues/86) Responses key supports both string, int, and
   HTTPStatus. Thanks, @CostcoFanboy.
 
 ## v2.4.0 2023-06-04
 
-- [#72](https://github.com/luolingchun/flask-openapi3/pull/72) security_schemes(SecurityScheme) supports a json format.
-- [#68](https://github.com/luolingchun/flask-openapi3/pull/68) feat: Add operation_id_callback. Thanks, @BoyanYK.
-- [#64](https://github.com/luolingchun/flask-openapi3/pull/64) Explains the usage of flask openapi command more clearly.
+- [#72](https://github.com/luolingchun/flask-openapi/pull/72) security_schemes(SecurityScheme) supports a json format.
+- [#68](https://github.com/luolingchun/flask-openapi/pull/68) feat: Add operation_id_callback. Thanks, @BoyanYK.
+- [#64](https://github.com/luolingchun/flask-openapi/pull/64) Explains the usage of flask openapi command more clearly.
   Thanks, @candleindark.
-- [#75](https://github.com/luolingchun/flask-openapi3/pull/75) Init view_class and pass view_kwargs. Thanks, @stufisher.
-- [#70](https://github.com/luolingchun/flask-openapi3/issues/70) Support for Specification Extensions in OpenAPI Object
+- [#75](https://github.com/luolingchun/flask-openapi/pull/75) Init view_class and pass view_kwargs. Thanks, @stufisher.
+- [#70](https://github.com/luolingchun/flask-openapi/issues/70) Support for Specification Extensions in OpenAPI Object
   and Operation Object. Thanks, @simonblund.
-- [#73](https://github.com/luolingchun/flask-openapi3/issues/73) BaseModel Config support openapi_extra.
+- [#73](https://github.com/luolingchun/flask-openapi/issues/73) BaseModel Config support openapi_extra.
 - Merge `extra_responses` to `responses` and deprecate `extra_responses`.
 
 **DeprecationWarning:**
@@ -211,7 +211,7 @@
 
 ## v2.3.2 2023-04-03
 
-- [#61](https://github.com/luolingchun/flask-openapi3/issues/61) Fix headers with pydantic alias
+- [#61](https://github.com/luolingchun/flask-openapi/issues/61) Fix headers with pydantic alias
 
 ## v2.3.1 2023-02-13
 
@@ -242,20 +242,20 @@
 
 ## v2.1.1 2022-10-12
 
-- [#41](https://github.com/luolingchun/flask-openapi3/issues/41) Set the `requestBody required` default value to True.
+- [#41](https://github.com/luolingchun/flask-openapi/issues/41) Set the `requestBody required` default value to True.
   Thanks, @Colin-b
 - Fix multi decorator for api
-- [#42](https://github.com/luolingchun/flask-openapi3/issues/42) Fix required header is not found when `_` in header
+- [#42](https://github.com/luolingchun/flask-openapi/issues/42) Fix required header is not found when `_` in header
   field. Thanks, @elirud
 
 ## v2.1.0 2022-09-04
 
-- [#36](https://github.com/luolingchun/flask-openapi3/issues/36) Add extra_form for operation. Thanks, @Colin-b
-- [#36](https://github.com/luolingchun/flask-openapi3/issues/36) Add extra_body for operation. Thanks, @Colin-b
+- [#36](https://github.com/luolingchun/flask-openapi/issues/36) Add extra_form for operation. Thanks, @Colin-b
+- [#36](https://github.com/luolingchun/flask-openapi/issues/36) Add extra_body for operation. Thanks, @Colin-b
 - Add external_docs for operation
 - Add servers for operation
 - Support to parse extra field in parameters
-- [#35](https://github.com/luolingchun/flask-openapi3/issues/35) Fixed extra_responses can now be used to set every
+- [#35](https://github.com/luolingchun/flask-openapi/issues/35) Fixed extra_responses can now be used to set every
   field in Response. Thanks, @Colin-b
 - Upgrade Swagger UI 4.14.0
 - Upgrade Redoc UI 2.0.0-rc.76
@@ -263,22 +263,22 @@
 
 ### Breaking Changes
 
-- [#39](https://github.com/luolingchun/flask-openapi3/issues/39) Remove configuration FLASK_OPENAPI_VALIDATE_RESPONSE
+- [#39](https://github.com/luolingchun/flask-openapi/issues/39) Remove configuration FLASK_OPENAPI_VALIDATE_RESPONSE
 
 ## v2.0.1 2022-08-07
 
-- [#32](https://github.com/luolingchun/flask-openapi3/issues/32) Fix: parse_rule is deprecated in werkzeug>=2.2.0.
+- [#32](https://github.com/luolingchun/flask-openapi/issues/32) Fix: parse_rule is deprecated in werkzeug>=2.2.0.
 
 ## v2.0.0 2022-06-26
 
-- [#26](https://github.com/luolingchun/flask-openapi3/issues/26) Fixed: Body throws exception when receiving str instead
+- [#26](https://github.com/luolingchun/flask-openapi/issues/26) Fixed: Body throws exception when receiving str instead
   of dict. Thanks, @nor3th
-- [#23](https://github.com/luolingchun/flask-openapi3/pull/23) Fixed externalDocs support. Thanks, @dvaerum
-- [#28](https://github.com/luolingchun/flask-openapi3/pull/28) Fixed to enable `__root__` property when validation
+- [#23](https://github.com/luolingchun/flask-openapi/pull/23) Fixed externalDocs support. Thanks, @dvaerum
+- [#28](https://github.com/luolingchun/flask-openapi/pull/28) Fixed to enable `__root__` property when validation
   responses. Thanks, @dvaerum
-- [#17](https://github.com/luolingchun/flask-openapi3/issues/17) Support for Nested APIBlueprint enhancement. Thanks,
+- [#17](https://github.com/luolingchun/flask-openapi/issues/17) Support for Nested APIBlueprint enhancement. Thanks,
   @dvaerum
-- [#29](https://github.com/luolingchun/flask-openapi3/pull/29) Support disable warnings. Thanks, @dvaerum
+- [#29](https://github.com/luolingchun/flask-openapi/pull/29) Support disable warnings. Thanks, @dvaerum
 - Support for empty response body. Thanks, @dvaerum
 - Support reload authorizations in Swagger UI
 - Add `flask openapi` command
@@ -297,20 +297,20 @@
 ## v1.1.3 2022-05-01
 
 - fix: Find globalns for the unwrapped func
-- [#19](https://github.com/luolingchun/flask-openapi3/issues/19) fix: Trailing slash in APIBlueprint. Thanks, @ev-agelos
+- [#19](https://github.com/luolingchun/flask-openapi/issues/19) fix: Trailing slash in APIBlueprint. Thanks, @ev-agelos
 - add description for UnprocessableEntity
 - remove printouts in `__init__.py`
 
 ## v1.1.2 2022-04-01
 
-- [#16](https://github.com/luolingchun/flask-openapi3/issues/16) Fix fileStorage list is not supported. Thanks, @tekrei
+- [#16](https://github.com/luolingchun/flask-openapi/issues/16) Fix fileStorage list is not supported. Thanks, @tekrei
 
 ## v1.1.0 2022-03-13
 
-- [#13](https://github.com/luolingchun/flask-openapi3/issues/13) drop support for flask 1.0.x. Thanks, @danmur
-- [#15](https://github.com/luolingchun/flask-openapi3/pull/15) Fix to enable BaseModel with `__root__` property. Thanks,
+- [#13](https://github.com/luolingchun/flask-openapi/issues/13) drop support for flask 1.0.x. Thanks, @danmur
+- [#15](https://github.com/luolingchun/flask-openapi/pull/15) Fix to enable BaseModel with `__root__` property. Thanks,
   @tarcisiojr
-- [#14](https://github.com/luolingchun/flask-openapi3/pull/14) Custom parameters: doc_prefix, api_doc_url, swagger_url,
+- [#14](https://github.com/luolingchun/flask-openapi/pull/14) Custom parameters: doc_prefix, api_doc_url, swagger_url,
   redoc_url, rapidoc_url. Thanks, @barryrobison
 - Upgrade swagger UI v4.6.2
 - Upgrade Redoc v2.0.0-rc.63
@@ -322,9 +322,9 @@
 
 ## v1.0.0 2022-01-11
 
-- [#10](https://github.com/luolingchun/flask-openapi3/issues/10) Fix: header's title case. Thanks, @rrr34
-- [#9](https://github.com/luolingchun/flask-openapi3/issues/9) Support for extra responses. Thanks, @blynn99
-- [#12](https://github.com/luolingchun/flask-openapi3/pull/12) Support for path operation field deprecated. Thanks,
+- [#10](https://github.com/luolingchun/flask-openapi/issues/10) Fix: header's title case. Thanks, @rrr34
+- [#9](https://github.com/luolingchun/flask-openapi/issues/9) Support for extra responses. Thanks, @blynn99
+- [#12](https://github.com/luolingchun/flask-openapi/pull/12) Support for path operation field deprecated. Thanks,
   @blynn99
 - Add keyword parameters `summary` and `description`
 - Add servers for OpenAPI
@@ -366,12 +366,12 @@
 
 - OpenAPI add responses and APIBlueprint add abp_responses
 - fix: validate response error when responses is empty dict
-- [#3](https://github.com/luolingchun/flask-openapi3/issues/3) endpoint and APIBlueprint add `doc_ui`. Thanks,
+- [#3](https://github.com/luolingchun/flask-openapi/issues/3) endpoint and APIBlueprint add `doc_ui`. Thanks,
   @DerManoMann
-- [#4](https://github.com/luolingchun/flask-openapi3/issues/4) fix: response description. Thanks, @DerManoMann
-- [#5](https://github.com/luolingchun/flask-openapi3/issues/5) add custom parameter `oauth_config`. Thanks, @DerManoMann
-- [#6](https://github.com/luolingchun/flask-openapi3/issues/6) support validation Flask Response. Thanks, @DerManoMann
-- [#7](https://github.com/luolingchun/flask-openapi3/issues/7) fix: response validation does not work when uses
+- [#4](https://github.com/luolingchun/flask-openapi/issues/4) fix: response description. Thanks, @DerManoMann
+- [#5](https://github.com/luolingchun/flask-openapi/issues/5) add custom parameter `oauth_config`. Thanks, @DerManoMann
+- [#6](https://github.com/luolingchun/flask-openapi/issues/6) support validation Flask Response. Thanks, @DerManoMann
+- [#7](https://github.com/luolingchun/flask-openapi/issues/7) fix: response validation does not work when uses
   http.HTTPStatus enums as status_code. Thanks, @DerManoMann
 
 ## v0.9.3 2021-06-08

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to Flask OpenAPI3.
 
-1. [Create a new issue](https://github.com/luolingchun/flask-openapi3/issues/new)
+1. [Create a new issue](https://github.com/luolingchun/flask-openapi/issues/new)
 2. [Fork and Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
 
 Before submitting pr, you need to complete the following steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-    <a href="https://luolingchun.github.io/flask-openapi3/" target="_blank">
-        <img class="off-glb" src="https://raw.githubusercontent.com/luolingchun/flask-openapi3/master/docs/images/logo-text.svg" 
+    <a href="https://luolingchun.github.io/flask-openapi/" target="_blank">
+        <img class="off-glb" src="https://raw.githubusercontent.com/luolingchun/flask-openapi/v4.x/docs/images/logo-text.svg" 
              width="60%" height="auto" alt="logo">
     </a>
 </div>
@@ -8,8 +8,8 @@
     <em>Generate REST API and OpenAPI documentation for your Flask project.</em>
 </p>
 <p align="center">
-    <a href="https://github.com/luolingchun/flask-openapi3/actions/workflows/tests.yml" target="_blank">
-        <img class="off-glb" src="https://img.shields.io/github/actions/workflow/status/luolingchun/flask-openapi3/tests.yml?branch=master" alt="test">
+    <a href="https://github.com/luolingchun/flask-openapi/actions/workflows/tests.yml" target="_blank">
+        <img class="off-glb" src="https://img.shields.io/github/actions/workflow/status/luolingchun/flask-openapi/tests.yml?branch=v4.x" alt="test">
     </a>
     <a href="https://pypi.org/project/flask-openapi3/" target="_blank">
         <img class="off-glb" src="https://img.shields.io/pypi/v/flask-openapi3" alt="pypi">
@@ -65,7 +65,7 @@ conda install -c conda-forge flask-openapi3[swagger]
   commands.
 - [pyyaml](https://github.com/yaml/pyyaml) is used to output the OpenAPI document in yaml format.
 - [asgiref](https://github.com/django/asgiref) allows views to be defined with `async def` and use `await`.
-- [flask-openapi3-plugins](https://github.com/luolingchun/flask-openapi3-plugins) Provide OpenAPI UI for flask-openapi3.
+- [flask-openapi-plugins](https://github.com/luolingchun/flask-openapi-plugins) Provide OpenAPI UI for flask-openapi3.
 
 To install these dependencies with flask-openapi3:
 
@@ -89,7 +89,7 @@ pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]
 
 ## A Simple Example
 
-Here's a simple example, further go to the [Example](https://luolingchun.github.io/flask-openapi3/latest/Example/).
+Here's a simple example, further go to the [Example](https://luolingchun.github.io/flask-openapi/v4.x/Example/).
 
 ```python
 from pydantic import BaseModel
@@ -198,13 +198,13 @@ if __name__ == "__main__":
 
 ## API Document
 
-Run the [simple example](https://github.com/luolingchun/flask-openapi3/blob/master/examples/simple_demo.py), and go to http://127.0.0.1:5000/openapi.
+Run the [simple example](https://github.com/luolingchun/flask-openapi/blob/v4.x/examples/simple_demo.py), and go to http://127.0.0.1:5000/openapi.
 
 > OpenAPI UI plugins are optional dependencies that require manual installation.
 >
 > `pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]`
 >
 > More optional ui templates goto the document
-> about [UI_Templates](https://luolingchun.github.io/flask-openapi3/latest/Usage/UI_Templates/).
+> about [UI_Templates](https://luolingchun.github.io/flask-openapi/v4.x/Usage/UI_Templates/).
 
-![openapi](https://raw.githubusercontent.com/luolingchun/flask-openapi3/master/docs/images/openapi-all.png)
+![openapi](https://raw.githubusercontent.com/luolingchun/flask-openapi/v4.x/docs/images/openapi-all.png)

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -125,7 +125,7 @@ if __name__ == '__main__':
 
 ## APIView
 
-[Class-based API View](./Reference/APIView.md), click [here](https://github.com/luolingchun/flask-openapi3/blob/master/examples/api_view_demo.py) for the complete example:
+[Class-based API View](./Reference/APIView.md), click [here](https://github.com/luolingchun/flask-openapi/blob/main/examples/api_view_demo.py) for the complete example:
 
 ```python
 @api_view.route("/book")

--- a/docs/Quickstart.zh.md
+++ b/docs/Quickstart.zh.md
@@ -126,7 +126,7 @@ if __name__ == '__main__':
 
 ## APIView
 
-[基于类的 API 视图](./Reference/APIView.md)， 点击[这里](https://github.com/luolingchun/flask-openapi3/blob/APIView/examples/api_view_demo.py) 查看完整示例:
+[基于类的 API 视图](./Reference/APIView.md)， 点击[这里](https://github.com/luolingchun/flask-openapi/blob/APIView/examples/api_view_demo.py) 查看完整示例:
 
 ```python
 @api_view.route("/book")

--- a/docs/Usage/Configuration.md
+++ b/docs/Usage/Configuration.md
@@ -5,7 +5,7 @@ configurations in this library that can be used.
 
 You can customize the custom behavior of this template.
 
-[The default `SWAGGER_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-swagger/flask_openapi3_swagger/templates/__init__.py).
+[The default `SWAGGER_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/main/flask-openapi-swagger/flask_openapi3_swagger/templates/__init__.py).
 
 ## SWAGGER_CONFIG
 
@@ -42,7 +42,7 @@ app.config["OAUTH_CONFIG"] = {"clientId": "xxx", "clientSecret": "xxx"}
 
 You can customize the custom behavior of this template.
 
-[The default `SCALAR_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-scalar/flask_openapi3_scalar/templates/__init__.py).
+[The default `SCALAR_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/main/flask-openapi-scalar/flask_openapi3_scalar/templates/__init__.py).
 
 ## SCALAR_CONFIG
 
@@ -53,7 +53,7 @@ You can change the default behavior of the Scalar UI.
 ## REDOC_HTML_STRING
 You can customize the custom behavior of this template.
 
-[The default `REDOC_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-redoc/flask_openapi3_redoc/templates/__init__.py).
+[The default `REDOC_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/main/flask-openapi-redoc/flask_openapi3_redoc/templates/__init__.py).
 
 ## REDOC_CONFIG
 
@@ -65,7 +65,7 @@ You can change the default behavior of the Redoc UI.
 
 You can customize the custom behavior of this template.
 
-[The default `RAPIDOC_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-rapidoc/flask_openapi3_rapidoc/templates/__init__.py).
+[The default `RAPIDOC_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/main/flask-openapi-rapidoc/flask_openapi3_rapidoc/templates/__init__.py).
 
 ## RAPIDOC_CONFIG
 
@@ -77,7 +77,7 @@ You can change the default behavior of the Rapidoc UI.
 
 You can customize the custom behavior of this template.
 
-[The default `RAPIPDF_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-rapipdf/flask_openapi3_rapipdf/templates/__init__.py).
+[The default `RAPIPDF_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/main/flask-openapi-rapipdf/flask_openapi3_rapipdf/templates/__init__.py).
 
 ## RAPIPDF_CONFIG
 
@@ -89,7 +89,7 @@ You can change the default behavior of the Rapipdf UI.
 
 You can customize the custom behavior of this template.
 
-[The default `ELEMENTS_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi3-plugins/blob/master/flask-openapi3-elements/flask_openapi3_elements/templates/__init__.py).
+[The default `ELEMENTS_HTML_STRING` is here](https://github.com/luolingchun/flask-openapi-plugins/blob/master/flask-openapi-elements/flask_openapi3_elements/templates/__init__.py).
 
 
 ## ELEMENTS_CONFIG

--- a/docs/Usage/UI_Templates.md
+++ b/docs/Usage/UI_Templates.md
@@ -21,4 +21,4 @@ pip install -U flask-openapi3-elements
 ```
 
 
-For more UI templates, please check the [plugin repository](https://github.com/luolingchun/flask-openapi3-plugins).
+For more UI templates, please check the [plugin repository](https://github.com/luolingchun/flask-openapi-plugins).

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <a href="https://luolingchun.github.io/flask-openapi3/" target="_blank">
+    <a href="https://luolingchun.github.io/flask-openapi/" target="_blank">
         <img class="off-glb" src="../images/logo-text.svg" width="60%" height="auto" alt="logo">
     </a>
 </div>
@@ -7,8 +7,8 @@
     <em>为你的 Flask 项目生成 REST API 和 OpenAPI 文档。</em>
 </p>
 <p align="center">
-    <a href="https://github.com/luolingchun/flask-openapi3/actions/workflows/tests.yml" target="_blank">
-        <img class="off-glb" src="https://img.shields.io/github/actions/workflow/status/luolingchun/flask-openapi3/tests.yml?branch=master" alt="test">
+    <a href="https://github.com/luolingchun/flask-openapi/actions/workflows/tests.yml" target="_blank">
+        <img class="off-glb" src="https://img.shields.io/github/actions/workflow/status/luolingchun/flask-openapi/tests.yml?branch=v4.x" alt="test">
     </a>
     <a href="https://pypi.org/project/flask-openapi3/" target="_blank">
         <img class="off-glb" src="https://img.shields.io/pypi/v/flask-openapi3" alt="pypi">
@@ -59,7 +59,7 @@ conda install -c conda-forge flask-openapi3
   命令时启用对[ dotenv 环境变量](https://flask.palletsprojects.com/en/latest/cli/#dotenv) 的支持；
 - [pyyaml](https://github.com/yaml/pyyaml) 用于输出 `yaml`格式的 OpenAPI 文档；
 - [asgiref](https://github.com/django/asgiref) 允许在定义视图函数时使用 `async def` 和 `await`；
-- [flask-openapi3-plugins](https://github.com/luolingchun/flask-openapi3-plugins) 为 Flask-OpenAPI3 提供 OpenAPI UI.
+- [flask-openapi-plugins](https://github.com/luolingchun/flask-openapi-plugins) 为 Flask-OpenAPI3 提供 OpenAPI UI.
 
 和 flask-openapi3 一起安装这些依赖:
 
@@ -83,7 +83,7 @@ pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]
 
 ## 一个简单的示例
 
-这里有一个简单的示例，更多示例请查看[示例](https://luolingchun.github.io/flask-openapi3/latest/zh/Example/)。
+这里有一个简单的示例，更多示例请查看[示例](https://luolingchun.github.io/flask-openapi/v4.x/zh/Example/)。
 
 ```python
 from pydantic import BaseModel
@@ -192,13 +192,13 @@ if __name__ == "__main__":
 
 ## API 文档
 
-运行[简单示例](https://github.com/luolingchun/flask-openapi3/blob/master/examples/simple_demo.py)，然后访问 http://127.0.0.1:5000/openapi。
+运行[简单示例](https://github.com/luolingchun/flask-openapi/blob/v4.x/examples/simple_demo.py)，然后访问 http://127.0.0.1:5000/openapi。
 
 > OpenAPI UI插件是需要手动安装的可选依赖项。
 > 
 > `pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]`
 > 
-> 更多可选[UI模板](https://luolingchun.github.io/flask-openapi3/latest/Usage/UI_Templates/)
+> 更多可选[UI模板](https://luolingchun.github.io/flask-openapi/v4.x/Usage/UI_Templates/)
 
 
 ![openapi](./images/openapi-all.png)

--- a/flask_openapi3/templates.py
+++ b/flask_openapi3/templates.py
@@ -100,7 +100,7 @@ a/x3gCx7M2rvrU8m3suK+3w+AcssZ50vnfwAAAABJRU5ErkJggg==
         $ pip install -U flask-openapi3[swagger,redoc,rapidoc,rapipdf,scalar,elements]
         </p>
         <p>More optional ui templates goto the document about
-        <a href="https://luolingchun.github.io/flask-openapi3/latest/Usage/UI_Templates/" style="color: #0969da">
+        <a href="https://luolingchun.github.io/flask-openapi/v4.x/Usage/UI_Templates/" style="color: #0969da">
         UI_Templates.
         </a>
         </p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: flask-openapi3
-site_url: https://luolingchun.github.io/flask-openapi3/
+site_name: flask-openapi
+site_url: https://luolingchun.github.io/flask-openapi/
 site_description: Generate REST API and OpenAPI documentation for your Flask project.
 site_author: llc
 
-repo_url: https://github.com/luolingchun/flask-openapi3
+repo_url: https://github.com/luolingchun/flask-openapi
 repo_name: 'GitHub'
 
 markdown_extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = ["Flask>=2.0", "pydantic>=2.4"]
 dynamic = ["version"]
 
 [project.urls]
-Homepage = "https://github.com/luolingchun/flask-openapi3"
-Documentation = "https://luolingchun.github.io/flask-openapi3"
+Homepage = "https://github.com/luolingchun/flask-openapi"
+Documentation = "https://luolingchun.github.io/flask-openapi"
 
 [project.optional-dependencies]
 yaml = ["pyyaml"]


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi tests examples` and no failed.
- [ ] Run `ruff format flask_openapi tests examples` and no failed.
- [ ] Run `ty check flask_openapi` and no failed.
- [ ] Run `mkdocs serve` and no failed.