### PR TITLE
Fix the trailing `/` caused by `register_api` with `url_prefix`

### DIFF
--- a/flask_openapi/openapi.py
+++ b/flask_openapi/openapi.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import re
 from importlib import import_module
 from importlib.metadata import entry_points
@@ -303,7 +304,9 @@ class OpenAPI(Flask):
             api.paths = {url_prefix + k.removeprefix(api.url_prefix): v for k, v in api.paths.items()}
             api.url_prefix = url_prefix
         elif url_prefix and not api.url_prefix:
-            api.paths = {url_prefix.rstrip("/") + "/" + k.lstrip("/"): v for k, v in api.paths.items()}
+            api.paths = {
+                posixpath.join(url_prefix, k.lstrip("/")) if k else url_prefix: v for k, v in api.paths.items()
+            }
             api.url_prefix = url_prefix
         self.paths.update(**api.paths)
 
@@ -341,7 +344,9 @@ class OpenAPI(Flask):
             api_view.paths = {url_prefix + k.removeprefix(api_view.url_prefix): v for k, v in api_view.paths.items()}
             api_view.url_prefix = url_prefix
         elif url_prefix and not api_view.url_prefix:
-            api_view.paths = {url_prefix.rstrip("/") + "/" + k.lstrip("/"): v for k, v in api_view.paths.items()}
+            api_view.paths = {
+                posixpath.join(url_prefix, k.lstrip("/")) if k else url_prefix: v for k, v in api_view.paths.items()
+            }
             api_view.url_prefix = url_prefix
         self.paths.update(**api_view.paths)
 

--- a/flask_openapi/utils.py
+++ b/flask_openapi/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import posixpath
 import re
 from http import HTTPMethod, HTTPStatus
 from typing import Any, Callable, DefaultDict, Type, get_type_hints
@@ -500,13 +501,11 @@ def run_validate_response(response: Any, responses: ResponseDict) -> Any:
 
 
 def parse_rule(rule: str, url_prefix=None) -> str:
-    trail_slash = rule.endswith("/")
-
     # Merge url_prefix and uri
-    uri = url_prefix.rstrip("/") + "/" + rule.lstrip("/") if url_prefix else rule
-
-    if not trail_slash:
-        uri = uri.rstrip("/")
+    if rule:
+        uri = posixpath.join(url_prefix, rule.lstrip("/")) if url_prefix else rule
+    else:
+        uri = url_prefix or ""
 
     # Convert a route parameter format from /pet/<petId> to /pet/{petId}
     uri = re.sub(r"<([^<:]+:)?", "{", uri).replace(">", "}")

--- a/tests/test_url_prefix.py
+++ b/tests/test_url_prefix.py
@@ -23,6 +23,10 @@ api2 = APIBlueprint("/book2", __name__)
 def create_book1(): ...
 
 
+@api2.get("")
+def get_book(): ...
+
+
 @api2.get("/book")
 def create_book2(): ...
 
@@ -53,7 +57,9 @@ app.register_api_view(api_view2, url_prefix="/api4")
 def test_openapi(client):
     resp = client.get("/openapi/openapi.json")
     _json = resp.json
-    assert "/api1/book" in _json["paths"].keys()
-    assert "/api2/book" in _json["paths"].keys()
-    assert "/api3/book" in _json["paths"].keys()
-    assert "/api4/book" in _json["paths"].keys()
+    paths = _json["paths"].keys()
+    assert "/api1/book" in paths
+    assert "/api2" in paths
+    assert "/api2/book" in paths
+    assert "/api3/book" in paths
+    assert "/api4/book" in paths


### PR DESCRIPTION
Checklist:

- [ ] Run `pytest tests` and no failed.
- [ ] Run `ruff check flask_openapi tests examples` and no failed.
- [ ] Run `ruff format flask_openapi tests examples` and no failed.
- [ ] Run `ty check flask_openapi` and no failed.
- [ ] Run `mkdocs serve` and no failed.